### PR TITLE
feat: Add SessionStart hook to remind pending learnings

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -32,6 +32,17 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/session_start_reminder.py\""
+          }
+        ]
+      }
     ]
   }
 }

--- a/scripts/session_start_reminder.py
+++ b/scripts/session_start_reminder.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Show pending learnings reminder at session start. SessionStart hook.
+
+Cross-platform compatible (Windows, macOS, Linux).
+This script is called by Claude Code's SessionStart hook to remind
+user of pending learnings that need review.
+"""
+import sys
+import os
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from lib.reflect_utils import load_queue
+
+
+def main() -> int:
+    """Main entry point."""
+    # Check if reminder is disabled via environment variable
+    if os.environ.get("CLAUDE_REFLECT_REMINDER", "true").lower() == "false":
+        return 0
+
+    items = load_queue()
+
+    if not items:
+        return 0
+
+    count = len(items)
+    print(f"\n{'='*50}")
+    print(f"📚 {count} pending learning(s) to review")
+    print(f"{'='*50}")
+
+    # Show up to 5 items
+    for i, item in enumerate(items[:5], 1):
+        msg = item.get("message", "")
+        # Truncate long messages
+        if len(msg) > 60:
+            msg = msg[:57] + "..."
+        confidence = item.get("confidence", 0.5)
+        print(f"  {i}. [{confidence:.0%}] {msg}")
+
+    if count > 5:
+        print(f"  ... and {count - 5} more")
+
+    print(f"\n💡 Run /reflect to review and apply")
+    print(f"{'='*50}\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as e:
+        # Never block on errors - just log and exit 0
+        print(f"Warning: session_start_reminder.py error: {e}", file=sys.stderr)
+        sys.exit(0)


### PR DESCRIPTION
## Summary

When user starts a new Claude Code session, if there are pending learnings in the queue, show a reminder with summary.

**Example output:**
```
==================================================
📚 2 pending learning(s) to review
==================================================
  1. [85%] Go 文件超 300 行应拆分
  2. [90%] 用中文回复

💡 Run /reflect to review and apply
==================================================
```

## Why

Currently, users need to remember to run `/reflect` manually. This can be easily forgotten, especially after a break.

By showing the reminder at **session start** (not end), it appears at the right time - when the user is ready to work and can immediately run `/reflect`.

## Features

- Shows up to 5 pending learnings with confidence scores
- Can be disabled via `CLAUDE_REFLECT_REMINDER=false` environment variable
- Cross-platform compatible (Windows, macOS, Linux)

## Changes

- Added `scripts/session_start_reminder.py` - the reminder script
- Updated `hooks/hooks.json` - added SessionStart hook