### PR TITLE
feat: SessionEnd hook + --context-loss and --workflows flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to claude-reflect will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **`SessionEnd` hook** — New `session_end_log.py` hook that fires at session end to
+  capture a structured activity summary (topics covered, tools used, corrections detected).
+  - Writes to `~/.claude/session-logs/YYYY-MM-DD-HHMMSS.md` by default
+  - Optional webhook: set `CLAUDE_REFLECT_SESSION_LOG_WEBHOOK=<url>` to POST JSON payload
+  - Optional command: set `CLAUDE_REFLECT_SESSION_LOG_COMMAND=<cmd>` to pipe JSON to a custom script
+  - Disable entirely: set `CLAUDE_REFLECT_SESSION_LOG=false`
+  - Skips very short sessions (< 4 messages) to avoid noise
+- **`/reflect --context-loss`** — Scans past sessions for patterns where the user had to
+  remind Claude of forgotten knowledge ("you forgot", "I told you", "read the rules").
+  Generates `docs/CONTEXT_LOSS_ANALYSIS.md` with categorized patterns and suggests a
+  SESSION RECOVERY section for `AGENTS.md` to prevent recurring context loss.
+- **`/reflect --workflows`** — Scans past sessions for recurring command sequences and
+  operational procedures. Generates `docs/WORKFLOWS.md` with copy-paste ready steps
+  grouped by category (build, deploy, test, etc.). Only includes patterns seen 3+ times.
+- **23 new tests** in `tests/test_session_end_log.py` covering parse_session, derive_topics,
+  format_markdown, format_json, write_local, and _extract_texts.
+
 ## [3.0.1] - 2026-02-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **23 new tests** in `tests/test_session_end_log.py` covering parse_session, derive_topics,
   format_markdown, format_json, write_local, and _extract_texts.
 
+### Fixed
+- **`CLAUDE_PLUGIN_ROOT` fallback in `hooks/hooks.json`** — All 5 hooks now use shell parameter
+  expansion `${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/claude-reflect-marketplace/claude-reflect}`
+  so hooks degrade gracefully instead of failing with a broken path when Claude Code does not
+  expand the variable (fixes #17).
+
 ## [3.0.1] - 2026-02-12
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ tests/                      → Test suite (pytest)
 - `scripts/lib/semantic_detector.py`: AI-powered semantic analysis via `claude -p`
 - `scripts/capture_learning.py`: Pattern detection (correction, positive, explicit markers) with confidence scoring
 - `scripts/check_learnings.py`: PreCompact hook that backs up queue before context compaction
+- `scripts/session_end_log.py`: SessionEnd hook that captures activity summary (topics, tools, corrections); writes local file or calls webhook/command
 - `scripts/extract_session_learnings.py`: Extracts user messages from session JSONL files
 - `scripts/extract_tool_rejections.py`: Extracts user corrections from tool rejections
 - `scripts/compare_detection.py`: Compare regex vs semantic detection on session data
@@ -87,6 +88,7 @@ The plugin registers via `.claude-plugin/plugin.json`:
 | UserPromptSubmit | `capture_learning.py` | Detect corrections and queue them |
 | PreCompact | `check_learnings.py` | Backup queue before compaction |
 | PostToolUse (Bash) | `post_commit_reminder.py` | Remind to /reflect after commits |
+| SessionEnd | `session_end_log.py` | Capture session activity summary |
 
 ## Detection Methods
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![GitHub stars](https://img.shields.io/github/stars/BayramAnnakov/claude-reflect?style=flat-square)](https://github.com/BayramAnnakov/claude-reflect/stargazers)
 [![Version](https://img.shields.io/badge/version-2.6.0-blue?style=flat-square)](https://github.com/BayramAnnakov/claude-reflect/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green?style=flat-square)](https://opensource.org/licenses/MIT)
-[![Tests](https://img.shields.io/badge/tests-160%20passing-brightgreen?style=flat-square)](https://github.com/BayramAnnakov/claude-reflect/actions)
+[![Tests](https://img.shields.io/badge/tests-220%20passing-brightgreen?style=flat-square)](https://github.com/BayramAnnakov/claude-reflect/actions)
 [![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey?style=flat-square)](https://github.com/BayramAnnakov/claude-reflect#platform-support)
 
 A self-learning system for Claude Code that captures corrections and discovers workflow patterns — turning them into permanent memory and reusable skills.
@@ -44,6 +44,9 @@ Example: You've asked "review my productivity" 12 times → suggests creating `/
 | **Skill Discovery** | Finds repeating patterns in your history → generates commands |
 | **Multi-language** | AI understands corrections in any language |
 | **Skill Improvement** | Corrections during `/deploy` improve the deploy skill itself |
+| **Session Logging** | Auto-captures session activity at end → local file + optional webhook |
+| **Context Loss Analysis** | Scans history for "you forgot" patterns → generates `CONTEXT_LOSS_ANALYSIS.md` |
+| **Workflow Extraction** | Finds recurring command sequences → generates `WORKFLOWS.md` |
 
 ## Installation
 
@@ -82,6 +85,8 @@ After installation, **restart Claude Code** (exit and reopen). Then hooks auto-c
 | `/reflect --targets` | Show detected config files (CLAUDE.md, AGENTS.md) |
 | `/reflect --review` | Show queue with confidence scores and decay status |
 | `/reflect --dedupe` | Find and consolidate similar entries in CLAUDE.md |
+| `/reflect --context-loss` | Scan sessions for "you forgot" patterns → `docs/CONTEXT_LOSS_ANALYSIS.md` |
+| `/reflect --workflows` | Extract recurring procedures → `docs/WORKFLOWS.md` |
 | `/reflect --include-tool-errors` | Include tool execution errors in scan |
 | `/reflect-skills` | Discover skill candidates from repeating patterns |
 | `/reflect-skills --days N` | Analyze last N days (default: 14) |
@@ -107,6 +112,7 @@ Hooks run automatically to detect and queue corrections:
 | `capture_learning.py` | Every prompt | Detects correction patterns and queues them |
 | `check_learnings.py` | Before compaction | Backs up queue and informs user |
 | `post_commit_reminder.py` | After git commit | Reminds to run /reflect after completing work |
+| `session_end_log.py` | Session end | Captures activity summary → local file or webhook |
 
 **Stage 2: Process (Manual)**
 

--- a/commands/reflect.md
+++ b/commands/reflect.md
@@ -13,6 +13,8 @@ allowed-tools: Read, Edit, Write, Glob, Bash, Grep, AskUserQuestion, TodoWrite
 - `--organize`: Analyze memory hierarchy and suggest reorganization across tiers.
 - `--include-tool-errors`: Include project-specific tool execution errors in scan (auto-enabled with `--scan-history`).
 - `--model MODEL`: Model for semantic analysis (default: `sonnet`). Use `haiku` for faster/cheaper runs or `opus` for maximum accuracy.
+- `--context-loss`: Scan past sessions for "you forgot / I told you / read the rules" patterns → generate `docs/CONTEXT_LOSS_ANALYSIS.md` and suggest a SESSION RECOVERY section for `AGENTS.md`.
+- `--workflows`: Extract recurring command sequences from past sessions → generate `docs/WORKFLOWS.md` with copy-paste ready procedures.
 
 ## Context
 - Project CLAUDE.md: @CLAUDE.md
@@ -443,6 +445,192 @@ Use AskUserQuestion for each proposed reorganization:
 - Preserve section structure in all files
 
 **6. Exit after reorganization (don't process queue).**
+
+### Handle --context-loss Argument
+
+**If user passed `--context-loss`:**
+
+Scan past sessions for patterns where the user had to remind Claude of something it forgot,
+then generate a `docs/CONTEXT_LOSS_ANALYSIS.md` report and suggest a SESSION RECOVERY section
+for `AGENTS.md`.
+
+**1. Find session files (same method as `--scan-history` Step 0.5a).**
+
+**2. Search for "forgotten knowledge" signals:**
+
+```bash
+# English patterns
+grep -h -o '"content":"[^"]*\(you forgot\|forgot how\|read the rules\|check docs\|you used to\|we already\|I told you\|I already told\|I said\|remember to\)[^"]*"' SESSION_FILES 2>/dev/null | head -50
+
+# Additional language patterns (adapt based on detected conversation language)
+# Spanish: "ya te dije\|te olvidaste\|lee las reglas"
+# German: "du hast vergessen\|ich habe dir gesagt\|lies die regeln"
+# Russian: "ты забыл\|я уже говорил\|прочитай правила"
+```
+
+**IMPORTANT**: Also detect when user says things like "no, use X" or "wrong, use Y" repeatedly across sessions for the same topic — these indicate recurring forgotten patterns, not just one-off corrections.
+
+**3. Categorize patterns:**
+
+| Category | Example signal | Fix type |
+|----------|---------------|----------|
+| **Build environment** | "compile on X not Y" | AGENTS.md quick command |
+| **Architecture** | "app is now native not web" | AGENTS.md architecture section |
+| **Tool location** | "use the script in scripts/, not the global one" | AGENTS.md paths table |
+| **Workflow** | "always run X before Y" | AGENTS.md quick commands |
+| **Project identity** | "we're on v2, not v1" | AGENTS.md project identity |
+| **Recurring correction** | Same "no, use X" pattern in 3+ sessions | Rules file candidate |
+
+**4. Generate `docs/CONTEXT_LOSS_ANALYSIS.md`:**
+
+```markdown
+# Context Loss Analysis
+
+Generated: YYYY-MM-DD | Sessions analyzed: N
+
+## Summary
+
+Found M patterns across N sessions where knowledge was repeatedly lost.
+
+## Patterns
+
+### 1. [Category: Build Environment]
+
+**User reminders found (N occurrences):**
+- "[exact quote]" — session abc123
+- "[exact quote]" — session def456
+
+**Root cause:** This information is not documented in AGENTS.md.
+
+**Recommended fix:** Add to AGENTS.md Quick Commands section.
+
+---
+
+### 2. [Category: ...]
+...
+
+## Recommendations
+
+| Priority | Fix | Where |
+|----------|-----|-------|
+| High | Add build target table | AGENTS.md → SESSION RECOVERY |
+| Medium | Document architecture state | AGENTS.md → Architecture section |
+```
+
+**5. Propose SESSION RECOVERY section for AGENTS.md:**
+
+Use AskUserQuestion to ask if they want to add a SESSION RECOVERY section to AGENTS.md:
+
+```markdown
+## SESSION RECOVERY (Read after compact/clear)
+
+### Critical Facts
+
+| Item | Value |
+|------|-------|
+| [Key 1] | [Value extracted from patterns] |
+| [Key 2] | [Value extracted from patterns] |
+
+### Quick Commands
+
+\`\`\`bash
+# [Task extracted from patterns]
+[command]
+\`\`\`
+```
+
+If user approves, prepend it near the top of AGENTS.md (or update existing section).
+
+**6. Exit after context loss analysis (don't process queue).**
+
+---
+
+### Handle --workflows Argument
+
+**If user passed `--workflows`:**
+
+Scan past sessions for recurring command sequences and operational procedures, then generate
+`docs/WORKFLOWS.md` with copy-paste ready instructions.
+
+**1. Find session files (same method as `--scan-history` Step 0.5a).**
+
+**2. Extract command patterns:**
+
+Search for tool calls, command sequences, and "how to do X" discussions:
+
+```bash
+# Find assistant messages with multiple bash commands in sequence
+grep -h '"type":"tool_use"' SESSION_FILES | grep '"name":"Bash"' | head -100
+
+# Find user messages asking for procedures
+grep -h -o '"content":"[^"]*\(how to\|how do I\|steps to\|procedure\|workflow\)[^"]*"' SESSION_FILES | head -50
+```
+
+**3. Identify workflow categories by frequency:**
+
+Group extracted commands by purpose. Common categories to look for:
+- File transfer (rsync, scp, cp)
+- Build processes (make, npm, cargo, go build)
+- Deployment (deploy, push, restart)
+- Testing (test, pytest, jest, cargo test)
+- Debugging (logs, status checks, diagnostics)
+- Database operations (migrate, seed, query)
+- Git operations (common multi-step sequences)
+
+Only include categories that appear **3 or more times** across sessions.
+
+**4. Generate `docs/WORKFLOWS.md`:**
+
+```markdown
+# Operational Workflows
+
+> Auto-generated by /reflect --workflows from session history.
+> Update manually as procedures evolve.
+
+## Index
+1. [Workflow A]
+2. [Workflow B]
+
+---
+
+## [Workflow Name]
+
+**Frequency:** Used N times across M sessions.
+
+### Prerequisites
+- [requirement]
+
+### Steps
+
+\`\`\`bash
+# Step 1: [Description]
+[exact command from session history]
+
+# Step 2: [Description]
+[exact command from session history]
+\`\`\`
+
+### Notes
+- [Any caveats or gotchas observed in sessions]
+
+### Troubleshooting
+- **Problem:** [X] → **Solution:** [Y]
+```
+
+**5. Show summary and ask user to review before writing:**
+
+```
+Found N workflow categories (M total procedures):
+  - Build & Deploy: 12 occurrences
+  - Database: 7 occurrences
+  - Testing: 5 occurrences
+
+Write docs/WORKFLOWS.md? (Y/n)
+```
+
+**6. Exit after workflow extraction (don't process queue).**
+
+---
 
 ### First-Run Detection (Per-Project)
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -43,6 +43,17 @@
           }
         ]
       }
+    ],
+    "SessionEnd": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/session_end_log.py\""
+          }
+        ]
+      }
     ]
   }
 }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/capture_learning.py\""
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/claude-reflect-marketplace/claude-reflect}/scripts/capture_learning.py\""
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/check_learnings.py\""
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/claude-reflect-marketplace/claude-reflect}/scripts/check_learnings.py\""
           }
         ]
       }
@@ -28,7 +28,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/post_commit_reminder.py\""
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/claude-reflect-marketplace/claude-reflect}/scripts/post_commit_reminder.py\""
           }
         ]
       }
@@ -39,7 +39,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/session_start_reminder.py\""
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/claude-reflect-marketplace/claude-reflect}/scripts/session_start_reminder.py\""
           }
         ]
       }
@@ -50,7 +50,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/session_end_log.py\""
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/claude-reflect-marketplace/claude-reflect}/scripts/session_end_log.py\""
           }
         ]
       }

--- a/scripts/session_end_log.py
+++ b/scripts/session_end_log.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+"""Capture session activity summary at session end. SessionEnd hook.
+
+Reads the completed session JSONL file and creates a structured activity
+log. Output is written to a local file and/or sent to a configurable
+webhook/command for integration with external knowledge systems.
+
+Cross-platform compatible (Windows, macOS, Linux).
+
+Environment variables:
+  CLAUDE_REFLECT_SESSION_LOG         "true" (default) or "false" to disable
+  CLAUDE_REFLECT_SESSION_LOG_WEBHOOK URL to POST session summary JSON to
+  CLAUDE_REFLECT_SESSION_LOG_COMMAND Shell command that receives JSON on stdin
+
+Output format (local file: ~/.claude/session-logs/YYYY-MM-DD-HHMMSS.md):
+  # Session Log: YYYY-MM-DD HH:MM
+  **Project:** /path/to/project
+  **Duration:** ~N messages
+
+  ## Topics Covered
+  - bullet list derived from user prompts
+
+  ## Tools Used
+  - Bash (N calls), Edit (N calls), ...
+
+  ## Corrections Captured
+  - learning 1
+  - learning 2
+"""
+import sys
+import os
+import json
+import re
+import urllib.request
+import subprocess
+from pathlib import Path
+from datetime import datetime, timezone
+from typing import List, Dict, Any, Optional
+from collections import Counter
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from lib.reflect_utils import (
+    get_claude_dir,
+    get_project_folder_name,
+    detect_patterns,
+    should_include_message,
+)
+
+
+# ---------------------------------------------------------------------------
+# Session file helpers
+# ---------------------------------------------------------------------------
+
+def find_session_file(project_dir: str, session_id: str) -> Optional[Path]:
+    """Locate the JSONL file for the current session."""
+    folder_name = get_project_folder_name(project_dir)
+    sessions_dir = get_claude_dir() / "projects" / folder_name
+
+    if not sessions_dir.exists():
+        return None
+
+    # Prefer exact session_id match
+    if session_id:
+        candidate = sessions_dir / f"{session_id}.jsonl"
+        if candidate.exists():
+            return candidate
+
+    # Fall back to most recently modified JSONL
+    jsonl_files = sorted(sessions_dir.glob("*.jsonl"), key=lambda p: p.stat().st_mtime)
+    return jsonl_files[-1] if jsonl_files else None
+
+
+def parse_session(session_file: Path) -> Dict[str, Any]:
+    """Parse a session JSONL file and extract a structured summary."""
+    user_messages: List[str] = []
+    tool_calls: List[str] = []
+    corrections: List[str] = []
+    message_count = 0
+
+    try:
+        with open(session_file, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+
+                msg_type = entry.get("type", "")
+                message_count += 1
+
+                # User messages → topic extraction + correction detection
+                if msg_type == "user" and not entry.get("isMeta"):
+                    content = entry.get("message", {}).get("content", [])
+                    texts = _extract_texts(content)
+                    for text in texts:
+                        if should_include_message(text):
+                            user_messages.append(text)
+                            _, _, confidence, _, _ = detect_patterns(text)
+                            if confidence >= 0.75:
+                                corrections.append(text)
+
+                # Tool use events → count by tool name
+                if msg_type == "assistant":
+                    content = entry.get("message", {}).get("content", [])
+                    if isinstance(content, list):
+                        for item in content:
+                            if isinstance(item, dict) and item.get("type") == "tool_use":
+                                tool_calls.append(item.get("name", "unknown"))
+
+    except IOError:
+        pass
+
+    tool_counts = Counter(tool_calls)
+    return {
+        "message_count": message_count,
+        "user_messages": user_messages,
+        "tool_counts": dict(tool_counts.most_common()),
+        "corrections": corrections,
+    }
+
+
+def _extract_texts(content: Any) -> List[str]:
+    if isinstance(content, str):
+        return [content]
+    if isinstance(content, list):
+        out = []
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "text":
+                out.append(item.get("text", ""))
+        return out
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Summary generation
+# ---------------------------------------------------------------------------
+
+def derive_topics(user_messages: List[str]) -> List[str]:
+    """Extract short topic descriptions from user messages (heuristic)."""
+    topics = []
+    seen: set = set()
+
+    for msg in user_messages:
+        # Take first line / first sentence, strip noise, cap at 80 chars
+        first_line = msg.split("\n")[0].strip()
+        first_line = re.sub(r"<[^>]+>", "", first_line)  # remove XML tags
+        first_line = first_line[:80].strip()
+        if len(first_line) > 10:
+            key = first_line.lower()[:40]
+            if key not in seen:
+                seen.add(key)
+                topics.append(first_line)
+        if len(topics) >= 10:
+            break
+
+    return topics
+
+
+def format_markdown(
+    project_dir: str,
+    session_id: str,
+    timestamp: str,
+    data: Dict[str, Any],
+) -> str:
+    """Format the session summary as Markdown."""
+    dt = datetime.now()
+    human_ts = dt.strftime("%Y-%m-%d %H:%M")
+
+    topics = derive_topics(data["user_messages"])
+    tool_summary = ", ".join(
+        f"{name} ({count})" for name, count in data["tool_counts"].items()
+    )
+
+    lines = [
+        f"# Session Log: {human_ts}",
+        f"",
+        f"**Project:** {project_dir}",
+        f"**Session:** {session_id}",
+        f"**Messages:** ~{data['message_count']}",
+        f"",
+    ]
+
+    if topics:
+        lines += ["## Topics Covered", ""]
+        for t in topics:
+            lines.append(f"- {t}")
+        lines.append("")
+
+    if tool_summary:
+        lines += ["## Tools Used", "", f"- {tool_summary}", ""]
+
+    if data["corrections"]:
+        lines += ["## Corrections Captured", ""]
+        for c in data["corrections"][:5]:
+            short = c[:100].replace("\n", " ")
+            lines.append(f"- {short}")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def format_json(
+    project_dir: str,
+    session_id: str,
+    timestamp: str,
+    data: Dict[str, Any],
+) -> str:
+    """Format the session summary as JSON for webhook delivery."""
+    payload = {
+        "event": "session_end",
+        "timestamp": timestamp,
+        "session_id": session_id,
+        "project_dir": project_dir,
+        "message_count": data["message_count"],
+        "topics": derive_topics(data["user_messages"]),
+        "tool_counts": data["tool_counts"],
+        "corrections": data["corrections"][:5],
+        "user_message_count": len(data["user_messages"]),
+    }
+    return json.dumps(payload, ensure_ascii=False, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# Output handlers
+# ---------------------------------------------------------------------------
+
+def write_local(markdown: str, timestamp: str) -> Optional[Path]:
+    """Write summary to ~/.claude/session-logs/."""
+    log_dir = get_claude_dir() / "session-logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    ts_safe = timestamp.replace(":", "").replace("T", "-").replace("Z", "")
+    log_file = log_dir / f"{ts_safe}.md"
+    log_file.write_text(markdown, encoding="utf-8")
+    return log_file
+
+
+def send_webhook(json_payload: str, url: str) -> bool:
+    """POST JSON payload to a webhook URL. Returns True on success."""
+    try:
+        data = json_payload.encode("utf-8")
+        req = urllib.request.Request(
+            url,
+            data=data,
+            headers={"Content-Type": "application/json", "User-Agent": "claude-reflect/session-log"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return resp.status < 400
+    except Exception:
+        return False
+
+
+def run_command(json_payload: str, command: str) -> bool:
+    """Pipe JSON payload into a shell command. Returns True on success."""
+    try:
+        result = subprocess.run(
+            command,
+            shell=True,
+            input=json_payload.encode("utf-8"),
+            timeout=15,
+        )
+        return result.returncode == 0
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    """Main entry point."""
+    # Respect opt-out
+    if os.environ.get("CLAUDE_REFLECT_SESSION_LOG", "true").lower() == "false":
+        return 0
+
+    # Read hook input from stdin
+    input_data = sys.stdin.read()
+    data = {}
+    if input_data:
+        try:
+            data = json.loads(input_data)
+        except json.JSONDecodeError:
+            pass
+
+    session_id = data.get("session_id", "")
+    project_dir = data.get("cwd") or os.environ.get("CLAUDE_PROJECT_DIR", "")
+
+    if not project_dir:
+        return 0
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    # Find and parse session file
+    session_file = find_session_file(project_dir, session_id)
+    if not session_file:
+        return 0
+
+    parsed = parse_session(session_file)
+
+    # Skip sessions with almost no content (e.g. accidental opens)
+    if parsed["message_count"] < 4 or not parsed["user_messages"]:
+        return 0
+
+    markdown = format_markdown(project_dir, session_id, timestamp, parsed)
+    json_payload = format_json(project_dir, session_id, timestamp, parsed)
+
+    # Always write local log
+    log_file = write_local(markdown, timestamp)
+
+    # Optional: send to webhook
+    webhook_url = os.environ.get("CLAUDE_REFLECT_SESSION_LOG_WEBHOOK", "")
+    if webhook_url:
+        send_webhook(json_payload, webhook_url)
+
+    # Optional: pipe to custom command
+    log_command = os.environ.get("CLAUDE_REFLECT_SESSION_LOG_COMMAND", "")
+    if log_command:
+        run_command(json_payload, log_command)
+
+    if log_file:
+        print(f"\n📋 Session logged → {log_file}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as e:
+        # Never block the session on errors
+        print(f"Warning: session_end_log.py error: {e}", file=sys.stderr)
+        sys.exit(0)

--- a/tests/test_session_end_log.py
+++ b/tests/test_session_end_log.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Tests for session_end_log module."""
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+# Add scripts directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from session_end_log import (
+    parse_session,
+    derive_topics,
+    format_markdown,
+    format_json,
+    write_local,
+    _extract_texts,
+)
+
+
+def _make_session_jsonl(messages: list) -> str:
+    """Build a minimal JSONL session file from a list of message dicts."""
+    return "\n".join(json.dumps(m) for m in messages)
+
+
+class TestExtractTexts(unittest.TestCase):
+    def test_string_content(self):
+        self.assertEqual(_extract_texts("hello"), ["hello"])
+
+    def test_list_content(self):
+        content = [{"type": "text", "text": "hello"}, {"type": "image"}]
+        self.assertEqual(_extract_texts(content), ["hello"])
+
+    def test_empty(self):
+        self.assertEqual(_extract_texts([]), [])
+        self.assertEqual(_extract_texts(None), [])
+
+
+class TestParseSession(unittest.TestCase):
+    def _write_session(self, messages: list) -> Path:
+        tmp = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".jsonl", delete=False, encoding="utf-8"
+        )
+        for msg in messages:
+            tmp.write(json.dumps(msg) + "\n")
+        tmp.close()
+        return Path(tmp.name)
+
+    def tearDown(self):
+        # Clean up temp files
+        pass
+
+    def test_counts_messages(self):
+        messages = [
+            {"type": "user", "isMeta": False, "message": {"content": [{"type": "text", "text": "hello"}]}},
+            {"type": "assistant", "message": {"content": []}},
+            {"type": "user", "isMeta": False, "message": {"content": [{"type": "text", "text": "world"}]}},
+        ]
+        f = self._write_session(messages)
+        result = parse_session(f)
+        self.assertEqual(result["message_count"], 3)
+        self.assertEqual(len(result["user_messages"]), 2)
+        f.unlink()
+
+    def test_skips_meta_messages(self):
+        messages = [
+            {"type": "user", "isMeta": True, "message": {"content": [{"type": "text", "text": "/reflect --dry-run"}]}},
+            {"type": "user", "isMeta": False, "message": {"content": [{"type": "text", "text": "real message"}]}},
+        ]
+        f = self._write_session(messages)
+        result = parse_session(f)
+        self.assertEqual(len(result["user_messages"]), 1)
+        self.assertEqual(result["user_messages"][0], "real message")
+        f.unlink()
+
+    def test_counts_tool_calls(self):
+        messages = [
+            {"type": "assistant", "message": {"content": [
+                {"type": "tool_use", "name": "Bash"},
+                {"type": "tool_use", "name": "Bash"},
+                {"type": "tool_use", "name": "Read"},
+            ]}},
+        ]
+        f = self._write_session(messages)
+        result = parse_session(f)
+        self.assertEqual(result["tool_counts"]["Bash"], 2)
+        self.assertEqual(result["tool_counts"]["Read"], 1)
+        f.unlink()
+
+    def test_detects_corrections(self):
+        messages = [
+            {"type": "user", "isMeta": False, "message": {"content": [
+                {"type": "text", "text": "no, use gpt-5.1 not gpt-4"}
+            ]}},
+            {"type": "user", "isMeta": False, "message": {"content": [
+                {"type": "text", "text": "looks good"}
+            ]}},
+        ]
+        f = self._write_session(messages)
+        result = parse_session(f)
+        self.assertEqual(len(result["corrections"]), 1)
+        self.assertIn("gpt-5.1", result["corrections"][0])
+        f.unlink()
+
+    def test_nonexistent_file(self):
+        result = parse_session(Path("/nonexistent/file.jsonl"))
+        self.assertEqual(result["message_count"], 0)
+        self.assertEqual(result["user_messages"], [])
+
+    def test_invalid_json_lines_skipped(self):
+        tmp = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".jsonl", delete=False, encoding="utf-8"
+        )
+        tmp.write("not json\n")
+        tmp.write(json.dumps({"type": "user", "isMeta": False, "message": {"content": "hi"}}) + "\n")
+        tmp.close()
+        result = parse_session(Path(tmp.name))
+        self.assertEqual(result["message_count"], 1)
+        Path(tmp.name).unlink()
+
+
+class TestDeriveTopics(unittest.TestCase):
+    def test_extracts_first_lines(self):
+        messages = ["fix the login bug", "add dark mode", "update dependencies"]
+        topics = derive_topics(messages)
+        self.assertEqual(len(topics), 3)
+        self.assertIn("fix the login bug", topics)
+
+    def test_deduplicates_similar(self):
+        # Messages share the same first 40 chars → deduplicated
+        base = "fix the authentication login flow bug in"  # exactly 40 chars
+        messages = [base + " production", base + " staging", "something else entirely"]
+        topics = derive_topics(messages)
+        self.assertEqual(len(topics), 2)
+
+    def test_strips_xml_tags(self):
+        messages = ["<system-reminder>ignore this</system-reminder>fix the bug"]
+        topics = derive_topics(messages)
+        self.assertFalse(any("<" in t for t in topics))
+
+    def test_caps_at_ten(self):
+        messages = [f"task number {i}" for i in range(20)]
+        topics = derive_topics(messages)
+        self.assertLessEqual(len(topics), 10)
+
+    def test_skips_short_messages(self):
+        messages = ["ok", "yes", "no", "this is a real message worth keeping"]
+        topics = derive_topics(messages)
+        short_included = [t for t in topics if len(t) <= 10]
+        self.assertEqual(short_included, [])
+
+
+class TestFormatMarkdown(unittest.TestCase):
+    def _sample_data(self):
+        return {
+            "message_count": 20,
+            "user_messages": ["fix the auth bug", "add dark mode", "update docs"],
+            "tool_counts": {"Bash": 5, "Edit": 3},
+            "corrections": ["no, use gpt-5.1 not gpt-4"],
+        }
+
+    def test_contains_project(self):
+        md = format_markdown("/my/project", "abc123", "2026-01-01T00:00:00Z", self._sample_data())
+        self.assertIn("/my/project", md)
+
+    def test_contains_tool_summary(self):
+        md = format_markdown("/p", "s", "t", self._sample_data())
+        self.assertIn("Bash (5)", md)
+        self.assertIn("Edit (3)", md)
+
+    def test_contains_corrections(self):
+        md = format_markdown("/p", "s", "t", self._sample_data())
+        self.assertIn("Corrections Captured", md)
+        self.assertIn("gpt-5.1", md)
+
+    def test_no_corrections_section_when_empty(self):
+        data = self._sample_data()
+        data["corrections"] = []
+        md = format_markdown("/p", "s", "t", data)
+        self.assertNotIn("Corrections Captured", md)
+
+    def test_no_tools_section_when_empty(self):
+        data = self._sample_data()
+        data["tool_counts"] = {}
+        md = format_markdown("/p", "s", "t", data)
+        self.assertNotIn("Tools Used", md)
+
+
+class TestFormatJson(unittest.TestCase):
+    def test_valid_json(self):
+        data = {
+            "message_count": 10,
+            "user_messages": ["hello", "world"],
+            "tool_counts": {"Bash": 2},
+            "corrections": [],
+        }
+        payload = format_json("/project", "sess123", "2026-01-01T00:00:00Z", data)
+        parsed = json.loads(payload)
+        self.assertEqual(parsed["event"], "session_end")
+        self.assertEqual(parsed["session_id"], "sess123")
+        self.assertEqual(parsed["message_count"], 10)
+        self.assertIn("topics", parsed)
+
+    def test_corrections_capped_at_five(self):
+        data = {
+            "message_count": 10,
+            "user_messages": [],
+            "tool_counts": {},
+            "corrections": [f"correction {i}" for i in range(10)],
+        }
+        payload = format_json("/p", "s", "t", data)
+        parsed = json.loads(payload)
+        self.assertLessEqual(len(parsed["corrections"]), 5)
+
+
+class TestWriteLocal(unittest.TestCase):
+    def test_writes_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("session_end_log.get_claude_dir", return_value=Path(tmpdir)):
+                path = write_local("# Test content\n", "2026-01-01T120000Z")
+                self.assertIsNotNone(path)
+                self.assertTrue(path.exists())
+                self.assertEqual(path.read_text(), "# Test content\n")
+
+    def test_creates_directory(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            claude_dir = Path(tmpdir) / "new_subdir"
+            with patch("session_end_log.get_claude_dir", return_value=claude_dir):
+                path = write_local("content", "2026-01-01T120000Z")
+                self.assertTrue(path.parent.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Three additions that extend claude-reflect beyond correction capture, addressing
the "other half" of the memory problem: recurring forgetting and undocumented workflows.

- **SessionEnd hook** — automatically logs session activity when a session ends
- **`/reflect --context-loss`** — scans history for "you forgot / I told you" *complaint* patterns (distinct from `--scan-history` corrections)
- **`/reflect --workflows`** — extracts recurring command sequences into a reusable workflows doc
- **Fix #17** — `CLAUDE_PLUGIN_ROOT` fallback in `hooks/hooks.json` so all hooks work when Claude Code does not expand the variable

## Changes

### 1. SessionEnd hook (`scripts/session_end_log.py`)

New hook that fires at session end and produces a structured summary:
- Topics covered (from user messages)
- Tools used and call counts
- Corrections detected in the session

**Output is configurable via env vars:**

| Env var | Default | Purpose |
|---------|---------|---------|
| `CLAUDE_REFLECT_SESSION_LOG` | `true` | Set to `false` to disable |
| `CLAUDE_REFLECT_SESSION_LOG_WEBHOOK` | _(unset)_ | POST JSON payload to this URL |
| `CLAUDE_REFLECT_SESSION_LOG_COMMAND` | _(unset)_ | Pipe JSON to this shell command |

Falls back to writing `~/.claude/session-logs/YYYY-MM-DD-HHMMSS.md` when no webhook/command is set.
Sessions with fewer than 4 messages are skipped to avoid noise.

### 2. `/reflect --context-loss`

**How it differs from `--scan-history`:**
- `--scan-history` finds direct corrections ("no, use X not Y") → adds entries to CLAUDE.md
- `--context-loss` finds *meta-complaints about recurring forgetting* ("you forgot again", "I already told you", "read the rules") → identifies systemic gaps

Generates `docs/CONTEXT_LOSS_ANALYSIS.md` with:
- Categorized patterns (build env, architecture, tool location, workflow, etc.)
- Frequency counts and example quotes per pattern
- Recommendations table (priority / fix / target file)

Also proposes a SESSION RECOVERY section for `AGENTS.md` so critical facts
survive context compaction — addressing the root cause rather than adding
yet another CLAUDE.md entry that gets forgotten too.

### 3. `/reflect --workflows`

Scans past sessions for recurring command sequences (threshold: 3+ occurrences).
Generates `docs/WORKFLOWS.md` grouped by category (build, deploy, test, database, git, etc.)
with copy-paste ready steps, observed caveats, and troubleshooting tips.

### 4. Fix: `CLAUDE_PLUGIN_ROOT` fallback (fixes #17)

All 5 hooks in `hooks/hooks.json` now use shell parameter expansion:

```
${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/claude-reflect-marketplace/claude-reflect}
```

When Claude Code does not expand `${CLAUDE_PLUGIN_ROOT}` before executing hook commands,
the path was resolving to `/scripts/...` (broken absolute path). The fallback targets
the canonical marketplace install location so hooks degrade gracefully instead of silently failing.

## Tests

23 new tests in `tests/test_session_end_log.py` covering:
`parse_session`, `derive_topics`, `format_markdown`, `format_json`, `write_local`, `_extract_texts`

**220 tests passing** (was 197 before this PR).
