### PR TITLE
fix: add CLAUDE_PLUGIN_ROOT fallback in hooks.json (fixes #17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to claude-reflect will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **`CLAUDE_PLUGIN_ROOT` fallback in `hooks/hooks.json`** — All 4 hooks now use shell parameter
+  expansion `${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/claude-reflect-marketplace/claude-reflect}`
+  so hooks degrade gracefully instead of failing with a broken path when Claude Code does not
+  expand the variable (fixes #17).
+
 ## [3.1.0] - 2026-03-16
 
 ### Added

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/capture_learning.py\""
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/claude-reflect-marketplace/claude-reflect}/scripts/capture_learning.py\""
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/check_learnings.py\""
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/claude-reflect-marketplace/claude-reflect}/scripts/check_learnings.py\""
           }
         ]
       }
@@ -28,7 +28,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/post_commit_reminder.py\""
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/claude-reflect-marketplace/claude-reflect}/scripts/post_commit_reminder.py\""
           }
         ]
       }
@@ -39,7 +39,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/session_start_reminder.py\""
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/claude-reflect-marketplace/claude-reflect}/scripts/session_start_reminder.py\""
           }
         ]
       }


### PR DESCRIPTION
## Summary
- All 4 hooks now use shell parameter expansion `${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/claude-reflect-marketplace/claude-reflect}` so hooks degrade gracefully when Claude Code does not expand the variable.
- Targeted fix for #17 — smallest possible change.

## Note
Split from #20 as requested. This is the easiest to merge and review.

## Test plan
- [ ] Install plugin via marketplace, verify hooks fire correctly
- [ ] Unset CLAUDE_PLUGIN_ROOT, verify fallback path is used