### PR TITLE
feat: follow inclusion graph from memory files to expand /reflect target scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Approved learnings are synced to:
 - `./**/CLAUDE.md` (subdirectories - auto-discovered)
 - `./.claude/commands/*.md` (skill files - when correction relates to a skill)
 - `AGENTS.md` (if exists - works with Codex, Cursor, Aider, Jules, Zed, Factory)
+- Docs reachable from the above via `@filename` includes or markdown links (bounded depth, cycles handled, code blocks/external URLs skipped) — useful when CLAUDE.md delegates guidance to `standards.md`, `architecture.md`, etc.
 
 Run `/reflect --targets` to see which files will be updated.
 

--- a/commands/reflect.md
+++ b/commands/reflect.md
@@ -34,6 +34,7 @@ Claude-reflect syncs learnings to CLAUDE.md files (including subdirectories), sk
 | **Subdirectory CLAUDE.md** | `./**/CLAUDE.md` | Markdown | Auto-discovered |
 | **Project Rules** | `./.claude/rules/*.md` | Markdown | Modular rules, optional path-scoping |
 | **User Rules** | `~/.claude/rules/*.md` | Markdown | Global modular rules |
+| **Referenced Docs** | docs reachable via `@` or markdown links | Markdown | Bounded inclusion-graph traversal from memory files |
 | **Skill Files** | `./commands/*.md` | Markdown | When correction relates to skill |
 | **Auto Memory** | `~/.claude/projects/<project>/memory/*.md` | Markdown | Low-confidence, exploratory learnings |
 | **AGENTS.md** | `./AGENTS.md` | Markdown | Industry standard (Codex, Cursor, Aider, Jules, Zed, Factory) |
@@ -45,7 +46,9 @@ Use the Python utility to find all memory tier files:
 from scripts.lib.reflect_utils import find_claude_files
 files = find_claude_files()
 # Returns list of {path, relative_path, type, frontmatter}
-# Types: 'global', 'root', 'local', 'subdirectory', 'rule', 'user-rule'
+# Types: 'global', 'root', 'local', 'subdirectory', 'rule', 'user-rule', 'referenced'
+# 'referenced' files are docs reachable from memory files via @-includes or
+# markdown links; they include 'referenced_from' and 'depth' fields.
 ```
 
 Or discover manually:
@@ -70,6 +73,7 @@ ls ~/.claude/rules/*.md 2>/dev/null
 - **Personal/local** (machine-specific, not for team) → `./CLAUDE.local.md`
 - **Low-confidence** (0.60-0.74) → auto memory for later promotion
 - **Project-specific** → `./CLAUDE.md` or subdirectory file
+- **Topic-aligned referenced docs** (e.g. `standards.md`, `architecture.md` reached via `@` or markdown links from CLAUDE.md / AGENTS.md) → that doc, when the learning matches its topic
 - Let users override routing with AI reasoning
 
 **Note on Confidence & Decay:**
@@ -181,6 +185,10 @@ Rule Files:
   ./.claude/rules/guardrails.md          8 lines  ✓
   ./.claude/rules/coding-style.md       15 lines  ✓  [paths: src/]
   ~/.claude/rules/model-preferences.md  10 lines  ✓
+
+Referenced Docs (via @ / markdown links):
+  ./docs/standards.md                    ← from ./CLAUDE.md            (depth 1)
+  ./docs/architecture.md                 ← from ./docs/standards.md    (depth 2)
 
 Auto Memory:
   ~/.claude/projects/.../memory/         3 files (general.md, tool-usage.md, workflow.md)

--- a/scripts/lib/reflect_utils.py
+++ b/scripts/lib/reflect_utils.py
@@ -6,6 +6,7 @@ Cross-platform compatible (Windows, macOS, Linux).
 import json
 import re
 import os
+from collections import deque
 from pathlib import Path
 from datetime import datetime, timezone
 from typing import List, Dict, Any, Optional, Tuple
@@ -187,17 +188,284 @@ def _parse_rule_frontmatter(filepath: Path) -> Optional[Dict[str, Any]]:
     return result if result else None
 
 
-def find_claude_files(root_dir: Optional[str] = None) -> List[Dict[str, Any]]:
+# =============================================================================
+# Inclusion graph traversal
+# =============================================================================
+#
+# Memory files (CLAUDE.md, AGENTS.md, rule files) often delegate guidance to
+# other docs via:
+#   - @filename            Claude Code's native include syntax
+#   - [text](relative.md)  standard markdown links
+#
+# These transitively-referenced docs are part of the project's de-facto AI
+# memory and should be reachable as routing targets in /reflect. The traversal
+# is bounded (depth cap + cycle detection) and skips fenced code blocks,
+# external URLs, and same-file anchors.
+
+# Default depth cap: 0 = seeds only, 1 = direct references, ...
+# 3 hops covers the typical CLAUDE.md → AGENTS.md → standards.md → details.md
+# chain. Real-world docs rarely delegate further.
+DEFAULT_INCLUSION_DEPTH = 3
+
+# Soft cap on total nodes discovered by inclusion-graph BFS, across all seeds.
+# Prevents pathological fanout from exhausting memory on a misconfigured tree.
+DEFAULT_INCLUSION_MAX_NODES = 200
+
+# Cap on bytes read from any single memory file when extracting inclusions.
+MAX_INCLUSION_FILE_BYTES = 1 * 1024 * 1024
+
+# @-include syntax: @path.md, @./path.md, @~/.claude/CLAUDE.md
+# Lookbehind prevents matching email addresses (foo@bar.md).
+_INCLUDE_RE = re.compile(r"(?<![\w.])@([\w./\-_~]+\.md)\b")
+
+# Inline markdown link: [text](target). Captures the target path.
+# Reference-style ([text][ref]) is intentionally not handled.
+_MD_LINK_RE = re.compile(r"\[[^\]]*\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)")
+
+# Fenced code block delimiters: ``` or ~~~ (any indentation, any info string).
+_FENCE_RE = re.compile(r"^\s*(?:```|~~~)")
+
+# External URL schemes — never followed.
+_EXTERNAL_SCHEME_RE = re.compile(r"^[a-z][a-z0-9+.\-]*:", re.IGNORECASE)
+
+
+def _parse_inclusions(filepath: Path) -> List[str]:
+    """Extract @-include and inline markdown link targets from a memory file.
+
+    Skips fenced code blocks, external URLs, and same-file anchors.
+    Strips in-page anchors (foo.md#section → foo.md). Reads are capped
+    at MAX_INCLUSION_FILE_BYTES; returns [] on any read error.
+
+    Returns:
+        Raw target strings in document order.
+    """
+    try:
+        with open(filepath, "rb") as fh:
+            blob = fh.read(MAX_INCLUSION_FILE_BYTES)
+    except (IOError, OSError):
+        return []
+    text = blob.decode("utf-8", errors="replace")
+
+    refs: List[str] = []
+    in_fence = False
+
+    for line in text.splitlines():
+        if _FENCE_RE.match(line):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+
+        for match in _INCLUDE_RE.finditer(line):
+            refs.append(match.group(1))
+
+        for match in _MD_LINK_RE.finditer(line):
+            target = match.group(1).strip()
+            if not target or target.startswith("#"):
+                continue
+            if _EXTERNAL_SCHEME_RE.match(target):
+                continue
+            if "#" in target:
+                target = target.split("#", 1)[0]
+            if target:
+                refs.append(target)
+
+    return refs
+
+
+def _resolve_inclusion(
+    target: str,
+    source_file: Path,
+    allowed_roots: Optional[List[Path]] = None,
+) -> Optional[Path]:
+    """Resolve a raw inclusion target to an absolute, existing .md file.
+
+    Handles ~ expansion, absolute paths, and paths relative to source_file's
+    directory. Restricts to .md files — checked on both the raw target and
+    the resolved suffix, so a `foo.md` symlink to /etc/passwd is rejected.
+
+    Confines the resolved path to `allowed_roots` when provided (typically
+    the project root plus ~/.claude/). When `allowed_roots` is None, no
+    containment check is applied — used by tests in isolation.
+
+    Returns the resolved Path, or None if any check fails.
+    """
+    if not target.endswith(".md"):
+        return None
+
+    raw = target.replace("\\", "/")  # Tolerate Windows-style separators in links
+
+    try:
+        if raw.startswith("~"):
+            candidate = Path(raw).expanduser()
+        elif Path(raw).is_absolute():
+            candidate = Path(raw)
+        else:
+            candidate = source_file.parent / raw
+        resolved = candidate.resolve()
+    except (OSError, ValueError):
+        return None
+
+    if resolved.suffix.lower() != ".md":
+        return None
+
+    try:
+        if not resolved.is_file():
+            return None
+    except OSError:
+        return None
+
+    if allowed_roots is not None:
+        for ancestor in allowed_roots:
+            try:
+                resolved.relative_to(ancestor)
+                break
+            except ValueError:
+                continue
+        else:
+            return None
+
+    return resolved
+
+
+def _format_relative_path(path: Path, root: Path) -> str:
+    """Format a path for display: project-relative, then home-relative, then absolute.
+
+    Both inputs are resolved to canonical form so symlinks (notably macOS's
+    /tmp → /private/tmp) don't break the relative_to() comparison. The
+    home-relative branch handles inclusions reached from the global
+    ~/.claude/CLAUDE.md (e.g., user-rules referenced by @ from there).
+    """
+    try:
+        canonical = path.resolve()
+    except OSError:
+        canonical = path
+    try:
+        canonical_root = root.resolve()
+    except OSError:
+        canonical_root = root
+
+    try:
+        rel = canonical.relative_to(canonical_root)
+        return f"./{rel.as_posix()}"
+    except ValueError:
+        pass
+    try:
+        rel = canonical.relative_to(Path.home().resolve())
+        return f"~/{rel.as_posix()}"
+    except (OSError, ValueError):
+        return canonical.as_posix()
+
+
+def _follow_inclusion_graph(
+    seed_files: List[Dict[str, Any]],
+    root: Path,
+    max_depth: int = DEFAULT_INCLUSION_DEPTH,
+    max_nodes: int = DEFAULT_INCLUSION_MAX_NODES,
+) -> List[Dict[str, Any]]:
+    """BFS over @-includes and markdown links from seed memory files.
+
+    Each newly discovered file is reported once with the immediate-parent
+    provenance. FIFO dequeue order means depth N is fully drained before
+    depth N+1, so reported `depth`/`referenced_from` reflect a shortest
+    path from the seed set.
+
+    Args:
+        seed_files: Result entries from the regular discovery pass. Each
+            must have a "path" key.
+        root: Project root. Inclusions confine to {root, get_claude_dir()}
+            so out-of-allowlist references (e.g. /etc/passwd.md) are rejected.
+        max_depth: Maximum hops from any seed (>=0). 0 disables traversal.
+        max_nodes: Cap on total newly-discovered files.
+
+    Returns:
+        List of dicts for newly discovered referenced docs (excluding seeds):
+            {path, relative_path, type='referenced', referenced_from, depth}
+    """
+    if max_depth <= 0 or not seed_files:
+        return []
+
+    try:
+        canonical_root = root.resolve()
+    except OSError:
+        canonical_root = root
+    try:
+        canonical_claude = get_claude_dir().resolve()
+    except OSError:
+        canonical_claude = get_claude_dir()
+    allowed_roots: List[Path] = [canonical_root, canonical_claude]
+
+    seen: set = set()
+    queue: "deque[Tuple[Path, int]]" = deque()
+    for f in seed_files:
+        try:
+            resolved = Path(f["path"]).resolve()
+        except OSError:
+            continue
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        queue.append((resolved, 0))
+    seed_paths = set(seen)
+
+    discovered: List[Dict[str, Any]] = []
+
+    while queue:
+        current, depth = queue.popleft()
+        if depth >= max_depth:
+            continue
+        if len(discovered) >= max_nodes:
+            break
+
+        formatted_current = _format_relative_path(current, root)
+
+        for raw_target in _parse_inclusions(current):
+            resolved = _resolve_inclusion(raw_target, current, allowed_roots)
+            if resolved is None or resolved in seen:
+                continue
+            seen.add(resolved)
+
+            if resolved in seed_paths:
+                continue
+
+            discovered.append({
+                "path": str(resolved),
+                "relative_path": _format_relative_path(resolved, root),
+                "type": "referenced",
+                "referenced_from": formatted_current,
+                "depth": depth + 1,
+            })
+            if len(discovered) >= max_nodes:
+                break
+            queue.append((resolved, depth + 1))
+
+    return discovered
+
+
+def find_claude_files(
+    root_dir: Optional[str] = None,
+    follow_includes: bool = True,
+    max_depth: int = DEFAULT_INCLUSION_DEPTH,
+    max_nodes: int = DEFAULT_INCLUSION_MAX_NODES,
+) -> List[Dict[str, Any]]:
     """
     Find all memory tier files in the project tree.
 
     Args:
-        root_dir: Root directory to search from (defaults to cwd)
+        root_dir: Root directory to search from (defaults to cwd).
+        follow_includes: If True (default), also surface .md docs that the
+            discovered memory files transitively reference via @-includes
+            or markdown links. Bounded by max_depth and cycle-safe; resolved
+            paths are confined to root_dir and ~/.claude/.
+        max_depth: Maximum hops to follow from any seed memory file when
+            follow_includes is True. Set to 0 to disable traversal.
+        max_nodes: Cap on total newly-discovered referenced files.
 
     Returns:
         List of dicts with {path, relative_path, type, ...} for each file found.
-        Types: 'global', 'root', 'local', 'subdirectory', 'rule', 'user-rule'.
-        Rule files include a 'frontmatter' field with parsed YAML frontmatter.
+        Types: 'global', 'root', 'local', 'subdirectory', 'rule', 'user-rule',
+        'referenced'. Rule files include a 'frontmatter' field. Referenced
+        files include 'referenced_from' and 'depth' fields.
     """
     root = Path(root_dir) if root_dir else Path.cwd()
     results = []
@@ -272,6 +540,12 @@ def find_claude_files(root_dir: Optional[str] = None) -> List[Dict[str, Any]]:
                 "type": "user-rule",
                 "frontmatter": frontmatter,
             })
+
+    # Follow inclusion graph to surface transitively referenced .md docs
+    if follow_includes:
+        results.extend(_follow_inclusion_graph(
+            results, root, max_depth=max_depth, max_nodes=max_nodes,
+        ))
 
     return results
 

--- a/tests/test_memory_hierarchy.py
+++ b/tests/test_memory_hierarchy.py
@@ -18,6 +18,9 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
 from lib.reflect_utils import (
     _parse_rule_frontmatter,
+    _parse_inclusions,
+    _resolve_inclusion,
+    _follow_inclusion_graph,
     find_claude_files,
     suggest_claude_file,
     get_project_folder_name,
@@ -399,6 +402,498 @@ class TestReadAllMemoryEntries(unittest.TestCase):
         entries = read_all_memory_entries(self.temp_dir)
         self.assertEqual(entries, [])
 
+    @patch("lib.reflect_utils.get_claude_dir")
+    def test_includes_referenced_file_bullets(self, mock_claude_dir):
+        """Bullets from inclusion-graph-discovered docs feed the dedup pool.
+
+        This is the load-bearing integration: /reflect's cross-tier dedup
+        only reaches docs that find_claude_files() surfaces.
+        """
+        fake_claude = Path(self.temp_dir) / "fake_claude"
+        fake_claude.mkdir()
+        mock_claude_dir.return_value = fake_claude
+
+        (Path(self.temp_dir) / "CLAUDE.md").write_text(
+            "# Project\n- Use postgres\n\nSee @standards.md\n"
+        )
+        (Path(self.temp_dir) / "standards.md").write_text(
+            "# Standards\n- Follow REST conventions\n- Async by default\n"
+        )
+
+        entries = read_all_memory_entries(self.temp_dir)
+        ref_entries = [e for e in entries if e["source_type"] == "referenced"]
+        texts = sorted(e["text"] for e in ref_entries)
+        self.assertEqual(texts, ["Async by default", "Follow REST conventions"])
+        self.assertEqual(ref_entries[0]["source_file"], "./standards.md")
+
+    @patch("lib.reflect_utils.get_claude_dir")
+    def test_rule_file_can_be_inclusion_source(self, mock_claude_dir):
+        """A doc referenced from a .claude/rules/*.md file is reachable."""
+        fake_claude = Path(self.temp_dir) / "fake_claude"
+        fake_claude.mkdir()
+        mock_claude_dir.return_value = fake_claude
+
+        (Path(self.temp_dir) / "CLAUDE.md").write_text("# P\n")
+        rules = Path(self.temp_dir) / ".claude" / "rules"
+        rules.mkdir(parents=True)
+        (rules / "python.md").write_text(
+            "# Python\nSee [Style](../../docs/style.md)\n"
+        )
+        docs = Path(self.temp_dir) / "docs"
+        docs.mkdir()
+        (docs / "style.md").write_text("# Style\n- 4-space indent\n")
+
+        from lib.reflect_utils import find_claude_files
+        files = find_claude_files(self.temp_dir)
+        ref = next(f for f in files if f["type"] == "referenced")
+        self.assertEqual(Path(ref["path"]).name, "style.md")
+        self.assertIn("python.md", ref["referenced_from"])
+
+
+class TestParseInclusions(unittest.TestCase):
+    """Tests for _parse_inclusions() — extracting @-includes and md-links."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _write(self, name, content):
+        path = Path(self.temp_dir) / name
+        path.write_text(content, encoding="utf-8")
+        return path
+
+    def test_at_include_simple(self):
+        """@filename.md is captured as an include."""
+        f = self._write("CLAUDE.md", "- See @AGENTS.md for details\n")
+        self.assertEqual(_parse_inclusions(f), ["AGENTS.md"])
+
+    def test_at_include_with_path(self):
+        """@-includes capture ~ and relative path forms verbatim."""
+        f = self._write(
+            "CLAUDE.md",
+            "- Project: @CLAUDE.md\n- Global: @~/.claude/CLAUDE.md\n- Sub: @./docs/standards.md\n",
+        )
+        refs = _parse_inclusions(f)
+        self.assertIn("CLAUDE.md", refs)
+        self.assertIn("~/.claude/CLAUDE.md", refs)
+        self.assertIn("./docs/standards.md", refs)
+
+    def test_at_include_skips_email_addresses(self):
+        """@-pattern doesn't match email addresses ending in .md."""
+        f = self._write("CLAUDE.md", "Contact: foo@bar.md is not an include\n")
+        self.assertEqual(_parse_inclusions(f), [])
+
+    def test_md_link_simple(self):
+        """[text](path.md) is captured."""
+        f = self._write("CLAUDE.md", "See [Standards](standards.md) for details.\n")
+        self.assertEqual(_parse_inclusions(f), ["standards.md"])
+
+    def test_md_link_with_title(self):
+        """Link with title attribute is captured (title stripped)."""
+        f = self._write("CLAUDE.md", '[Doc](./docs/api.md "API Doc")\n')
+        self.assertEqual(_parse_inclusions(f), ["./docs/api.md"])
+
+    def test_md_link_skips_external_urls(self):
+        """https://, http://, mailto:, and other schemes are ignored."""
+        f = self._write(
+            "CLAUDE.md",
+            "[GitHub](https://github.com/x.md)\n"
+            "[Site](http://example.com/y.md)\n"
+            "[Mail](mailto:foo@bar.com)\n",
+        )
+        self.assertEqual(_parse_inclusions(f), [])
+
+    def test_md_link_skips_anchor_only(self):
+        """[text](#section) is a same-file anchor and skipped."""
+        f = self._write("CLAUDE.md", "[Top](#top)\n[Section](#section-1)\n")
+        self.assertEqual(_parse_inclusions(f), [])
+
+    def test_md_link_strips_in_page_anchor(self):
+        """[text](foo.md#section) → foo.md (anchor stripped)."""
+        f = self._write("CLAUDE.md", "[Section](standards.md#api)\n")
+        self.assertEqual(_parse_inclusions(f), ["standards.md"])
+
+    def test_skips_fenced_code_blocks(self):
+        """References inside ``` and ~~~ fences are not captured."""
+        f = self._write(
+            "CLAUDE.md",
+            "Real: @real.md\n"
+            "```\n@fake.md\n[ignored](nope.md)\n```\n"
+            "Mid: @mid.md\n"
+            "~~~\n@tilde.md\n~~~\n"
+            "After: @after.md\n",
+        )
+        refs = _parse_inclusions(f)
+        self.assertIn("real.md", refs)
+        self.assertIn("mid.md", refs)
+        self.assertIn("after.md", refs)
+        self.assertNotIn("fake.md", refs)
+        self.assertNotIn("nope.md", refs)
+        self.assertNotIn("tilde.md", refs)
+
+    def test_unreadable_file_returns_empty(self):
+        """Missing or unreadable file yields no refs (pins error branch)."""
+        self.assertEqual(_parse_inclusions(Path("/nonexistent/file.md")), [])
+
+
+class TestResolveInclusion(unittest.TestCase):
+    """Tests for _resolve_inclusion() — path resolution + safety checks."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_resolve_relative_to_source_dir(self):
+        """Relative target resolves against the source file's directory."""
+        sub = Path(self.temp_dir) / "sub"
+        sub.mkdir()
+        (sub / "AGENTS.md").write_text("# A")
+        (sub / "standards.md").write_text("# S")
+        result = _resolve_inclusion("standards.md", sub / "AGENTS.md")
+        self.assertEqual(result, (sub / "standards.md").resolve())
+
+    def test_resolve_absolute_path(self):
+        """Absolute target is used as-is."""
+        target = Path(self.temp_dir) / "abs.md"
+        target.write_text("# X")
+        result = _resolve_inclusion(str(target), Path(self.temp_dir) / "src.md")
+        self.assertEqual(result, target.resolve())
+
+    def test_resolve_rejects_non_md(self):
+        """Non-.md targets return None even if the file exists."""
+        sub = Path(self.temp_dir) / "sub"
+        sub.mkdir()
+        (sub / "script.py").write_text("print('x')")
+        result = _resolve_inclusion("script.py", sub / "CLAUDE.md")
+        self.assertIsNone(result)
+
+    def test_resolve_rejects_missing_file(self):
+        """Targets pointing at non-existent files return None."""
+        result = _resolve_inclusion(
+            "missing.md", Path(self.temp_dir) / "src.md"
+        )
+        self.assertIsNone(result)
+
+    def test_resolve_rejects_directory(self):
+        """Directories named foo.md are not memory targets."""
+        d = Path(self.temp_dir) / "weird.md"
+        d.mkdir()
+        result = _resolve_inclusion("weird.md", Path(self.temp_dir) / "src.md")
+        self.assertIsNone(result)
+
+
+class TestFollowInclusionGraph(unittest.TestCase):
+    """Tests for _follow_inclusion_graph() — bounded BFS traversal."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.root = Path(self.temp_dir)
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _seed(self, path):
+        return [{"path": str(path), "relative_path": "./CLAUDE.md", "type": "root"}]
+
+    def test_one_hop_at_include(self):
+        """CLAUDE.md → @AGENTS.md is discovered."""
+        claude = self.root / "CLAUDE.md"
+        agents = self.root / "AGENTS.md"
+        claude.write_text("- See @AGENTS.md\n")
+        agents.write_text("# Agents\n")
+
+        discovered = _follow_inclusion_graph(self._seed(claude), self.root)
+        self.assertEqual(len(discovered), 1)
+        entry = discovered[0]
+        self.assertEqual(entry["type"], "referenced")
+        self.assertEqual(entry["depth"], 1)
+        self.assertEqual(entry["relative_path"], "./AGENTS.md")
+        self.assertEqual(entry["referenced_from"], "./CLAUDE.md")
+
+    def test_one_hop_md_link(self):
+        """CLAUDE.md → [Standards](standards.md) is discovered."""
+        claude = self.root / "CLAUDE.md"
+        standards = self.root / "standards.md"
+        claude.write_text("[Standards](standards.md)\n")
+        standards.write_text("# S\n")
+
+        discovered = _follow_inclusion_graph(self._seed(claude), self.root)
+        self.assertEqual(len(discovered), 1)
+        self.assertEqual(discovered[0]["relative_path"], "./standards.md")
+
+    def test_two_hops(self):
+        """CLAUDE.md → AGENTS.md → standards.md surfaces both."""
+        claude = self.root / "CLAUDE.md"
+        agents = self.root / "AGENTS.md"
+        standards = self.root / "standards.md"
+        claude.write_text("- @AGENTS.md\n")
+        agents.write_text("- [Standards](standards.md)\n")
+        standards.write_text("# Standards\n")
+
+        discovered = _follow_inclusion_graph(self._seed(claude), self.root)
+        paths = sorted(d["relative_path"] for d in discovered)
+        self.assertEqual(paths, ["./AGENTS.md", "./standards.md"])
+
+        depth_by_name = {Path(d["path"]).name: d["depth"] for d in discovered}
+        self.assertEqual(depth_by_name["AGENTS.md"], 1)
+        self.assertEqual(depth_by_name["standards.md"], 2)
+        # Provenance: standards.md was reached via AGENTS.md
+        std_entry = next(d for d in discovered if Path(d["path"]).name == "standards.md")
+        self.assertEqual(std_entry["referenced_from"], "./AGENTS.md")
+
+    def test_depth_cap_stops_traversal(self):
+        """max_depth=1 stops after one hop."""
+        a = self.root / "CLAUDE.md"
+        b = self.root / "B.md"
+        c = self.root / "C.md"
+        a.write_text("@B.md\n")
+        b.write_text("@C.md\n")
+        c.write_text("# C\n")
+
+        discovered = _follow_inclusion_graph(self._seed(a), self.root, max_depth=1)
+        names = sorted(Path(d["path"]).name for d in discovered)
+        self.assertEqual(names, ["B.md"])
+
+    def test_depth_cap_zero_disables_traversal(self):
+        """max_depth=0 means no traversal."""
+        a = self.root / "CLAUDE.md"
+        b = self.root / "B.md"
+        a.write_text("@B.md\n")
+        b.write_text("# B\n")
+
+        discovered = _follow_inclusion_graph(self._seed(a), self.root, max_depth=0)
+        self.assertEqual(discovered, [])
+
+    def test_cycle_safe(self):
+        """A → B → A does not infinitely loop, and each file is reported once."""
+        a = self.root / "CLAUDE.md"
+        b = self.root / "B.md"
+        a.write_text("@B.md\n")
+        b.write_text("@CLAUDE.md\n")
+
+        discovered = _follow_inclusion_graph(self._seed(a), self.root)
+        names = [Path(d["path"]).name for d in discovered]
+        self.assertEqual(names, ["B.md"])  # CLAUDE.md is a seed, not reported
+
+    def test_diamond_dedup(self):
+        """A→B and A→C both linking to D yields D only once."""
+        a = self.root / "CLAUDE.md"
+        b = self.root / "B.md"
+        c = self.root / "C.md"
+        d = self.root / "D.md"
+        a.write_text("@B.md\n@C.md\n")
+        b.write_text("@D.md\n")
+        c.write_text("@D.md\n")
+        d.write_text("# D\n")
+
+        discovered = _follow_inclusion_graph(self._seed(a), self.root)
+        d_entries = [x for x in discovered if Path(x["path"]).name == "D.md"]
+        self.assertEqual(len(d_entries), 1)
+
+    def test_seed_skipped_when_referenced(self):
+        """Following a reference back to an existing seed doesn't re-emit it."""
+        claude = self.root / "CLAUDE.md"
+        local = self.root / "CLAUDE.local.md"
+        claude.write_text("@CLAUDE.local.md\n")
+        local.write_text("# Local\n")
+
+        seeds = [
+            {"path": str(claude), "relative_path": "./CLAUDE.md", "type": "root"},
+            {"path": str(local), "relative_path": "./CLAUDE.local.md", "type": "local"},
+        ]
+        discovered = _follow_inclusion_graph(seeds, self.root)
+        self.assertEqual(discovered, [])
+
+    @patch("lib.reflect_utils.get_claude_dir")
+    def test_path_outside_allowlist_is_rejected(self, mock_claude_dir):
+        """References escaping {project root, ~/.claude} are not surfaced.
+
+        Defends against pasted-in [x](/etc/passwd.md) markdown turning the
+        host filesystem into routing targets.
+        """
+        # Point fake claude dir well away from the test's outside_root so
+        # the external file is in neither allowed root.
+        fake_claude = self.root / "fake_claude"
+        fake_claude.mkdir()
+        mock_claude_dir.return_value = fake_claude
+
+        outside_root = Path(tempfile.mkdtemp())
+        try:
+            external = outside_root / "external.md"
+            external.write_text("# External\n")
+
+            claude = self.root / "CLAUDE.md"
+            claude.write_text(f"[X]({external})\n")
+
+            discovered = _follow_inclusion_graph(self._seed(claude), self.root)
+            self.assertEqual(discovered, [])
+        finally:
+            import shutil
+            shutil.rmtree(outside_root, ignore_errors=True)
+
+    @patch("lib.reflect_utils.get_claude_dir")
+    def test_symlink_to_non_md_is_rejected(self, mock_claude_dir):
+        """A `.md` symlink that resolves to a non-md file is rejected.
+
+        Defends against `evil.md → /etc/passwd` patterns where the raw target
+        passes the `.md` check but the resolved file is something else.
+        """
+        if os.name == "nt":
+            self.skipTest("Symlink creation requires admin on Windows")
+
+        fake_claude = self.root / "fake_claude"
+        fake_claude.mkdir()
+        mock_claude_dir.return_value = fake_claude
+
+        # Real non-md file inside the project (so allowlist passes)
+        real = self.root / "secrets.txt"
+        real.write_text("sensitive\n")
+
+        # Symlink with .md extension pointing at the non-md file
+        evil = self.root / "evil.md"
+        try:
+            evil.symlink_to(real)
+        except (OSError, NotImplementedError):
+            self.skipTest("Symlinks not supported in this environment")
+
+        claude = self.root / "CLAUDE.md"
+        claude.write_text("@evil.md\n")
+
+        discovered = _follow_inclusion_graph(self._seed(claude), self.root)
+        self.assertEqual(discovered, [])
+
+    def test_bfs_shortest_path_provenance(self):
+        """When two paths reach the same file, depth + parent reflect the shorter one.
+
+        Setup: A→C (1 hop) and A→B→C (2 hops). C must end up at depth 1
+        with referenced_from=A, not depth 2 via B.
+        """
+        a = self.root / "CLAUDE.md"
+        b = self.root / "B.md"
+        c = self.root / "C.md"
+        # A references both C (direct) and B (which also references C)
+        a.write_text("@C.md\n@B.md\n")
+        b.write_text("@C.md\n")
+        c.write_text("# C\n")
+
+        discovered = _follow_inclusion_graph(self._seed(a), self.root)
+        c_entry = next(d for d in discovered if Path(d["path"]).name == "C.md")
+        self.assertEqual(c_entry["depth"], 1)
+        self.assertEqual(c_entry["referenced_from"], "./CLAUDE.md")
+
+    def test_max_nodes_caps_traversal(self):
+        """max_nodes bounds the total number of newly-discovered files."""
+        a = self.root / "CLAUDE.md"
+        a.write_text("\n".join(f"@f{i}.md" for i in range(10)) + "\n")
+        for i in range(10):
+            (self.root / f"f{i}.md").write_text("# x\n")
+
+        discovered = _follow_inclusion_graph(
+            self._seed(a), self.root, max_nodes=3,
+        )
+        self.assertEqual(len(discovered), 3)
+
+    def test_multiple_links_one_line(self):
+        """Multiple links on a single line are all captured."""
+        a = self.root / "CLAUDE.md"
+        for name in ("a.md", "b.md", "c.md"):
+            (self.root / name).write_text("# x\n")
+        a.write_text("See [A](a.md), [B](b.md), and [C](c.md).\n")
+
+        discovered = _follow_inclusion_graph(self._seed(a), self.root)
+        names = sorted(Path(d["path"]).name for d in discovered)
+        self.assertEqual(names, ["a.md", "b.md", "c.md"])
+
+
+
+class TestFindClaudeFilesWithInclusions(unittest.TestCase):
+    """Tests for find_claude_files() with inclusion graph traversal."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.root = Path(self.temp_dir)
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    @patch("lib.reflect_utils.get_claude_dir")
+    def test_referenced_files_appear_in_results(self, mock_claude_dir):
+        """Files transitively referenced via @ and md-links are surfaced."""
+        fake_claude = self.root / "fake_claude"
+        fake_claude.mkdir()
+        mock_claude_dir.return_value = fake_claude
+
+        (self.root / "CLAUDE.md").write_text("@AGENTS.md\n[Std](standards.md)\n")
+        (self.root / "AGENTS.md").write_text("- @architecture.md\n")
+        (self.root / "architecture.md").write_text("# Arch\n")
+        (self.root / "standards.md").write_text("# Std\n")
+
+        files = find_claude_files(self.temp_dir)
+        referenced = [f for f in files if f["type"] == "referenced"]
+        names = sorted(Path(f["path"]).name for f in referenced)
+        self.assertEqual(names, ["AGENTS.md", "architecture.md", "standards.md"])
+
+    @patch("lib.reflect_utils.get_claude_dir")
+    def test_follow_includes_can_be_disabled(self, mock_claude_dir):
+        """follow_includes=False returns no referenced files."""
+        fake_claude = self.root / "fake_claude"
+        fake_claude.mkdir()
+        mock_claude_dir.return_value = fake_claude
+
+        (self.root / "CLAUDE.md").write_text("@AGENTS.md\n")
+        (self.root / "AGENTS.md").write_text("# A\n")
+
+        files = find_claude_files(self.temp_dir, follow_includes=False)
+        referenced = [f for f in files if f["type"] == "referenced"]
+        self.assertEqual(referenced, [])
+
+    @patch("lib.reflect_utils.get_claude_dir")
+    def test_referenced_does_not_double_with_seed(self, mock_claude_dir):
+        """A subdirectory CLAUDE.md referenced by root CLAUDE.md isn't duplicated."""
+        fake_claude = self.root / "fake_claude"
+        fake_claude.mkdir()
+        mock_claude_dir.return_value = fake_claude
+
+        (self.root / "CLAUDE.md").write_text("@src/CLAUDE.md\n")
+        sub = self.root / "src"
+        sub.mkdir()
+        (sub / "CLAUDE.md").write_text("# Src\n")
+
+        files = find_claude_files(self.temp_dir)
+        # src/CLAUDE.md should appear once as 'subdirectory', not 'referenced'
+        sub_path = str((sub / "CLAUDE.md").resolve())
+        matching = [f for f in files if Path(f["path"]).resolve() == Path(sub_path)]
+        self.assertEqual(len(matching), 1)
+        self.assertEqual(matching[0]["type"], "subdirectory")
+
+    @patch("lib.reflect_utils.get_claude_dir")
+    def test_auto_discovery_still_excludes_node_modules(self, mock_claude_dir):
+        """Auto-discovery exclusion holds even when inclusion follow is on.
+
+        Note: explicit references INTO an excluded dir are still followed
+        (the user wrote them) — that's a deliberate trust boundary. This
+        test only asserts that auto-walking doesn't pull in node_modules.
+        """
+        fake_claude = self.root / "fake_claude"
+        fake_claude.mkdir()
+        mock_claude_dir.return_value = fake_claude
+
+        nm = self.root / "node_modules"
+        nm.mkdir()
+        (nm / "CLAUDE.md").write_text("# Should NOT be discovered\n")
+
+        (self.root / "CLAUDE.md").write_text("# P\n")
+
+        files = find_claude_files(self.temp_dir)
+        self.assertFalse(any("node_modules" in f["path"] for f in files))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #34.

## Summary
- Memory files (CLAUDE.md, AGENTS.md, rule files) often delegate guidance to other docs via Claude Code's `@filename` includes or markdown links. Today those docs are outside `/reflect`'s scope, so a learning that belonged in `standards.md` drifts into CLAUDE.md.
- `find_claude_files()` now performs a bounded BFS over `@`-includes and inline markdown links from the discovered memory files and surfaces the reached `.md` docs as `type='referenced'` entries with `referenced_from` + `depth` provenance.
- Routing UI offers them like CLAUDE.md targets; user picks per-learning.

## Concrete example

```
CLAUDE.md  →  @AGENTS.md  →  [Coding Standards](./docs/standards.md)
                          →  [Architecture](./docs/architecture.md)
```

After this change, all four files are reachable as `/reflect` targets.

## Constraints honored
- **Bounded traversal** — `DEFAULT_INCLUSION_DEPTH = 3`
- **Bounded breadth** — `DEFAULT_INCLUSION_MAX_NODES = 200`
- **Bounded reads** — `MAX_INCLUSION_FILE_BYTES = 1 MiB`
- **Cycle-safe** — visited-set; A→B→A and self-references don't loop
- **Shortest-path provenance** — BFS dequeue order; pinned by `test_bfs_shortest_path_provenance`
- **Skips fenced code blocks** — both ` ``` ` and `~~~`
- **Skips external URLs** — any scheme (`https:`, `mailto:`, …)
- **Skips same-file anchors** — `[text](#section)`; in-page anchors stripped from path links
- **`.md`-only targets** — checked on both the raw target and the *resolved* path, so a symlinked `evil.md → /etc/passwd` is rejected
- **Allowlisted paths** — resolved paths confined to `{root_dir, get_claude_dir()}`; pasted-in `[x](/etc/passwd.md)` can't surface arbitrary filesystem paths
- **Email-safe regex** — `(?<![\w.])@…` lookbehind prevents matching `foo@bar.md`
- **Inline markdown links only** — reference-style `[text][ref]` is intentionally not handled

## API
`find_claude_files(root_dir, follow_includes=True, max_depth=3, max_nodes=200)` — defaults on; pass `follow_includes=False` or `max_depth=0` to opt out. `'referenced'` entries carry `referenced_from` and `depth`.

## Files changed (~783 LOC: 282 impl + 495 tests + 11 docs)
- `scripts/lib/reflect_utils.py` — `_parse_inclusions`, `_resolve_inclusion`, `_format_relative_path`, `_follow_inclusion_graph`, plus the `find_claude_files()` integration
- `tests/test_memory_hierarchy.py` — 34 new tests across 4 classes covering parsing, resolution, traversal, security clamps, and the `read_all_memory_entries` integration
- `commands/reflect.md` — adds `Referenced Docs` row to target table, updates type list, extends `--targets` display, adds routing hint
- `README.md` — one bullet under Multi-Target Sync

## Test plan
- [x] 222 existing tests still pass unchanged
- [x] 34 new tests pass (256 total)
- [x] Smoke test on this repo's own CLAUDE.md: surfaces `RELEASING.md` (real `[RELEASING.md](RELEASING.md)` link in `CLAUDE.md`)
- [x] `capture_learning.py` and `check_learnings.py` hooks still run
- [x] Python 3.9 verified locally; type hints stay 3.8-compatible
- [x] macOS `/tmp` → `/private/tmp` symlink handled
- [x] Security: out-of-allowlist paths rejected; symlink-to-non-md rejected
- [x] DoS: 1 MiB file cap, 200-node fanout cap

## Backward compatibility
- Existing types unchanged
- New keys (`referenced_from`, `depth`) only on `'referenced'` entries
- All existing tests that filter by type or assert `assertIn("root", types)` continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)