### PR TITLE
fix(capture): skip harness-injected pseudo-prompts (task-notification…

### DIFF
--- a/scripts/capture_learning.py
+++ b/scripts/capture_learning.py
@@ -57,6 +57,18 @@ def main() -> int:
     if _stripped.startswith(_IGNORED_PREFIXES):
         return 0
 
+    # Some harness events prepend a banner (e.g. "[SYSTEM NOTIFICATION - NOT
+    # USER INPUT]") before the actual <task-notification>/<system-reminder>
+    # block, so a prefix match alone misses them. Skip on the marker anywhere.
+    _IGNORED_MARKERS = (
+        "<task-notification>",
+        "[SYSTEM NOTIFICATION - NOT USER INPUT]",
+        "[from automated background-task event",
+        "This is an automated background-task event",
+    )
+    if any(_marker in prompt for _marker in _IGNORED_MARKERS):
+        return 0
+
     # Initialize queue if doesn't exist
     queue_path = get_queue_path()
     if not queue_path.exists():

--- a/scripts/capture_learning.py
+++ b/scripts/capture_learning.py
@@ -38,6 +38,25 @@ def main() -> int:
     if not prompt:
         return 0
 
+    # Ignore harness-injected pseudo-prompts that aren't actual user input.
+    # Background sub-agent completion blobs, system reminders, slash-command
+    # expansions, and persisted-output dumps all flow through UserPromptSubmit
+    # but are not learnings — they're typically multi-KB and contain English
+    # words ("perfect", "no", "use") that trip the pattern detector. See
+    # CLAUDE.md / MEMORY.md hook-bug note (2026-05-10).
+    _stripped = prompt.lstrip()
+    _IGNORED_PREFIXES = (
+        "<task-notification>",   # sub-agent (Agent tool) completion
+        "<system-reminder>",     # harness-injected reminder
+        "<command-message>",     # /slash-command expansion message
+        "<command-name>",        # /slash-command name marker
+        "<persisted-output>",    # large output dump persisted to file
+        "<user-prompt-submit-hook>",  # hook-output echo
+        "<command-args>",        # /slash-command args marker
+    )
+    if _stripped.startswith(_IGNORED_PREFIXES):
+        return 0
+
     # Initialize queue if doesn't exist
     queue_path = get_queue_path()
     if not queue_path.exists():


### PR DESCRIPTION
…, system-reminder, etc.)

The UserPromptSubmit hook fires for every prompt the model receives, including harness-injected blobs that aren't actual user input:

- <task-notification> — background sub-agent (Agent tool) completion summaries; multi-KB blobs that always contain words like "Perfect!" / "Done." that trip the positive-sentiment detector
- <system-reminder> — harness-injected reminders (task-tracking, CLAUDE.md re-load, hook output echoes) that often contain corrective- sounding text from the harness itself, not the user
- <command-message> / <command-name> / <command-args> — slash-command expansion markers
- <persisted-output> — large-output dumps replaced by a file reference
- <user-prompt-submit-hook> — output echo from previous hook runs

Symptoms observed in a multi-agent session (Claude Code Opus 4.7, 10 parallel sub-agents): the learnings queue accumulated 10 entries in a single day, of which 9 were sub-agent completion blobs and only 1 was a real user correction. Total queue size: 313 KB. /reflect then had to manually filter the noise on every invocation.

Fix: early-return at the top of main() when prompt.lstrip() starts with any of the 7 known harness-injection prefixes. Real corrections (starting with text the user typed) still flow through the detector.

Verified end-to-end:
  - task-notification + "Perfect!" inside → not queued
  - real "no, use parameterized queries" prompt → queued (auto type)
  - system-reminder + "Perfect for testing" inside → not queued

No behavior change for the existing pattern detector; this is a pre- filter only. Backward-compatible.