### PR TITLE
fix(detect): drop slash-command + forward-pivot false positives

### DIFF
--- a/scripts/lib/reflect_utils.py
+++ b/scripts/lib/reflect_utils.py
@@ -618,6 +618,25 @@ CJK_CORRECTION_PATTERNS = [
 # Exception: explicit "remember:" markers are always processed regardless of length.
 MAX_CAPTURE_PROMPT_LENGTH = 500
 
+# Forward-pivot patterns — phrases that indicate the message body is a
+# task instruction following a positive-feedback opener, NOT retrospective
+# feedback. "Perfect! Now let's add X" is structurally a task pivot, not
+# validation of past work. Applied ONLY to positive-pattern matches; real
+# corrections (e.g. "Now let's stop refactoring") still get captured by
+# CORRECTION_PATTERNS since those signals are directive-as-content, not
+# directive-as-followup.
+#
+# Distinct from FALSE_POSITIVE_PATTERNS (which apply to all detections)
+# and NON_CORRECTION_PHRASES (which neutralize correction openers like
+# "no problem"). This list neutralizes positive openers when the message
+# body is a fresh request rather than reflection on past behavior.
+FORWARD_PIVOT_PATTERNS = [
+    r"\b(now|next)[, ]+(let'?s|we|i)\b",        # "Now let's", "Next, we", "Now I"
+    r"\blet'?s (add|do|build|move|update|change|fix|implement)\b",
+    r"\b(go ahead and|can you|could you|please)\b",
+    r"\bwe need to\b",
+]
+
 # Maximum message length for weak patterns (structural heuristic)
 # Long messages are more likely to be context/tasks than corrections
 MAX_WEAK_PATTERN_LENGTH = 150
@@ -638,6 +657,15 @@ def detect_patterns(text: str) -> Tuple[Optional[str], str, float, str, int]:
         sentiment: "correction" or "positive"
         decay_days: Number of days until decay
     """
+    # Slash-command guard — /loop, /reflect, /ia:full-review etc. expand
+    # into long skill bodies that incidentally contain correction tokens
+    # (e.g. "use" + "not" in unrelated text). Slash commands are skill
+    # invocations, never user feedback, so they should never enter the
+    # queue. This is the FIRST check because no downstream pattern
+    # (explicit, positive, correction, guardrail) should fire on them.
+    if text.lstrip().startswith("/"):
+        return (None, "", 0.0, "correction", 90)
+
     # Too short to be actionable (e.g. "OK", "好", "yes")
     # CJK characters carry more meaning per char, so use a lower threshold
     stripped = text.strip()
@@ -675,6 +703,15 @@ def detect_patterns(text: str) -> Tuple[Optional[str], str, float, str, int]:
             matched_positive.append(name)
 
     if matched_positive:
+        # Forward-pivot guard — "Perfect! Now let's add X" matches the
+        # positive pattern but the body is a fresh task instruction, not
+        # retrospective feedback. Reject so we don't pollute the queue
+        # with task pivots (which are never reusable learnings).
+        # Applied ONLY here, not to corrections — "Now let's stop X" is
+        # a legitimate correction even when phrased as a task pivot.
+        for fp_pattern in FORWARD_PIVOT_PATTERNS:
+            if re.search(fp_pattern, text, re.IGNORECASE):
+                return (None, "", 0.0, "correction", 90)
         return ("positive", " ".join(matched_positive), 0.70, "positive", 90)
 
     # Skip long messages for weak patterns (likely task requests)

--- a/tests/test_reflect_utils.py
+++ b/tests/test_reflect_utils.py
@@ -504,6 +504,115 @@ class TestCJKPatternDetection(unittest.TestCase):
         self.assertEqual(result[0], "guardrail")
 
 
+class TestStructuralRejection(unittest.TestCase):
+    """Tests for the structural rejection guards in detect_patterns —
+    slash-command bodies and forward-pivot phrases that follow positive
+    feedback. These short-circuit pattern detection regardless of which
+    correction / positive / explicit patterns also match.
+    """
+
+    # ── Slash-command guard ──────────────────────────────────────────────
+    # /loop, /reflect, /ia:full-review etc. expand into long skill bodies
+    # that incidentally contain "use", "not", "perfect", etc. They are
+    # skill invocations, never user feedback, so detect_patterns should
+    # short-circuit on a leading "/" before any pattern check.
+
+    def test_slash_command_loop_not_captured(self):
+        """/loop ... bodies must not capture even if they contain 'use'/'not'."""
+        prompt = "/loop Keep polling the build status; use the artifact URL not the run URL when reporting."
+        result = detect_patterns(prompt)
+        self.assertIsNone(result[0])
+        self.assertEqual(result[1], "")
+
+    def test_slash_command_ia_full_review_not_captured(self):
+        """/ia:full-review bodies must not capture despite directive verbs."""
+        prompt = "/ia:full-review --deep please run the chain against the latest commit."
+        result = detect_patterns(prompt)
+        self.assertIsNone(result[0])
+
+    def test_slash_command_with_leading_whitespace_not_captured(self):
+        """A leading newline/space before / must not bypass the guard."""
+        prompt = "\n  /reflect --dry-run perfect! check whether the queue is clean"
+        result = detect_patterns(prompt)
+        self.assertIsNone(result[0])
+
+    def test_slash_command_with_remember_marker_not_captured(self):
+        """Even an explicit 'remember:' inside a slash-command body
+        must NOT capture — slash commands are non-user-feedback by structure.
+        """
+        prompt = "/loop remember: this should not be captured because it's inside a slash-command body"
+        result = detect_patterns(prompt)
+        self.assertIsNone(result[0])
+
+    def test_non_slash_messages_still_capture_normally(self):
+        """Regression guard: messages NOT starting with / are unaffected
+        by the slash-command check (sanity that the guard isn't too greedy).
+        """
+        result = detect_patterns("remember: always use bun")
+        self.assertEqual(result[0], "explicit")
+
+    # ── Forward-pivot guard for positive matches ─────────────────────────
+    # "Perfect! Now let's add X" hits POSITIVE_PATTERNS but the body is
+    # a forward-looking task instruction, not retrospective feedback.
+    # The guard rejects ONLY positive matches when a forward-pivot
+    # phrase is also present.
+
+    def test_positive_with_now_lets_pivot_rejected(self):
+        """'Perfect! Now let's add X' is a task pivot — must not capture."""
+        result = detect_patterns(
+            "Perfect! Now let's add the new column to the modal "
+            "right after the title field."
+        )
+        self.assertIsNone(result[0])
+
+    def test_positive_with_lets_implement_pivot_rejected(self):
+        """'Perfect, exactly right! Let's implement that fix' — task pivot."""
+        result = detect_patterns(
+            "perfect! exactly right. Let's implement the partition-pruning fix now."
+        )
+        self.assertIsNone(result[0])
+
+    def test_positive_with_can_you_pivot_rejected(self):
+        """'Perfect! Can you also update X' — request, not retrospective feedback."""
+        result = detect_patterns(
+            "Nailed it! Can you also update the README with the new flags?"
+        )
+        self.assertIsNone(result[0])
+
+    def test_positive_pure_feedback_still_captures(self):
+        """Pure positive feedback (no task pivot) still captures — the
+        guard rejects ONLY positive matches with forward-pivot phrases.
+        Required to prove the guard isn't over-greedy.
+        """
+        result = detect_patterns(
+            "Perfect, that's exactly what I wanted — the GDU projection "
+            "approach was the right call because the simple engine "
+            "doesn't emit V-stages."
+        )
+        self.assertEqual(result[0], "positive")
+        self.assertEqual(result[3], "positive")
+
+    def test_correction_with_pivot_still_captures(self):
+        """Forward-pivot guard is scoped to POSITIVE matches only.
+        'Now let's stop using X' is a correction directive even though
+        it contains a pivot phrase — must still capture as 'auto'.
+        """
+        result = detect_patterns(
+            "Now let's stop using the legacy regex approach; "
+            "use the structural filter instead, not the pattern list."
+        )
+        self.assertEqual(result[0], "auto")
+
+    def test_guardrail_with_pivot_still_captures(self):
+        """Guardrails are checked BEFORE positive — pivot guard doesn't
+        leak into the guardrail branch.
+        """
+        result = detect_patterns(
+            "Now let's stop refactoring unrelated code, please."
+        )
+        self.assertEqual(result[0], "guardrail")
+
+
 class TestQueueItemCreation(unittest.TestCase):
     """Tests for queue item creation."""
 


### PR DESCRIPTION
## Summary

Two false-positive lanes in `detect_patterns` were polluting the queue with prompts that are structurally not user feedback:

1. **Slash-command bodies** — `/loop`, `/reflect`, `/ia:full-review` etc. expand into long skill bodies that incidentally contain correction tokens. They're skill invocations, never feedback.
2. **"Perfect! Now let's …" task pivots** — a positive opener followed by a forward-looking task instruction. The body is a fresh request, not retrospective feedback.

## Why these slipped past existing filters

- `FALSE_POSITIVE_PATTERNS` covers question marks and "please/can you/help me" task openers, but neither applies to slash-commands (no question mark, no help-me phrasing) or to "Perfect! Now let's …" (doesn't start with the task verbs in that list).
- `NON_CORRECTION_PHRASES` covers correction-opener false positives ("No problem", "Don't worry") but doesn't cover positive-opener false positives.
- The `use .{1,30} not\b` tightening from a prior PR helps with the correction side, but slash-commands often contain "use" / "not" in unrelated context far apart, which the gap limit doesn't always catch.

## Fix shape

### 1. Slash-command guard (top of `detect_patterns`)

```python
if text.lstrip().startswith("/"):
    return (None, "", 0.0, "correction", 90)
```

Placed BEFORE the explicit `remember:` check — a slash-command body that happens to contain a literal "remember:" token still shouldn't capture, since the structural signal (skill invocation) dominates.

### 2. Forward-pivot guard (positive-match branch only)

New constant:

```python
FORWARD_PIVOT_PATTERNS = [
    r"\b(now|next)[, ]+(let'?s|we|i)\b",
    r"\blet'?s (add|do|build|move|update|change|fix|implement)\b",
    r"\b(go ahead and|can you|could you|please)\b",
    r"\bwe need to\b",
]
```

Checked **inside the positive-match branch only**:

```python
if matched_positive:
    for fp_pattern in FORWARD_PIVOT_PATTERNS:
        if re.search(fp_pattern, text, re.IGNORECASE):
            return (None, "", 0.0, "correction", 90)
    return ("positive", ...)
```

This is intentionally narrower than `FALSE_POSITIVE_PATTERNS` — corrections like "Now let's stop using X" SHOULD still capture (they're correction directives), so the pivot phrases only suppress positive matches.

## Sample inputs

| Prompt | Before | After |
|---|---|---|
| `/loop Keep polling... use the artifact URL not the run URL` | `auto` (use-X-not-Y) | rejected |
| `/reflect --dry-run perfect! check whether queue is clean` | `positive` (perfect) | rejected |
| `Perfect! Now let's add the new column` | `positive` (perfect) | rejected |
| `Perfect, that's exactly what I wanted — the approach was right` | `positive` | `positive` (unchanged — pure feedback) |
| `Now let's stop using the legacy regex; use X not Y` | `auto` | `auto` (unchanged — correction directive) |
| `Now let's stop refactoring unrelated code` | `guardrail` | `guardrail` (unchanged — guardrail checked first) |

## Tests

11 new tests in a new `TestStructuralRejection` class:
- 5 cover the slash-command guard (`/loop`, `/ia:full-review`, leading-whitespace `/reflect`, slash + `remember:`, plus a regression that non-slash messages still capture).
- 6 cover the forward-pivot guard (3 rejection scenarios, plus 3 regressions that pure positive feedback / corrections-with-pivot / guardrails-with-pivot still capture as expected).

Full suite: **233/233 pass** (`python3 -m unittest discover -s tests`).

## Origin

Found in the wild while running `/reflect` on a real-world project queue. Two distinct false-positive instances surfaced one week apart (slash-commands first, then "Perfect! Now let's …" after a routine UX feedback session). Both have the same shape: a structural signal in the message (skill prefix / pivot phrase) dominates the lexical pattern match. Adding structural guards at the detection boundary is more durable than tightening individual regexes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)