### PR TITLE
fix(windows): capture corrections on Windows (drive-colon path + cp1252 stdout)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to claude-reflect will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Windows: corrections were never captured.** `get_project_folder_name()` left the drive colon in the encoded project folder (e.g. `-C:-Users-bob-app`), which is an illegal Windows directory name. The `learnings-queue.json` / auto-memory `mkdir` raised `WinError 267`, `capture_learning.py` swallowed it and exited 0, so the queue file was never created and no corrections were recorded. The encoder now replaces `:` as well as the path separators, and drops the spurious leading dash, matching Claude Code's own folder names (`C:\Users\bob\app` becomes `C--Users-bob-app`). Added a cross-platform regression test plus an end-to-end hook test.
+- **Windows: hook output crashed on cp1252 consoles.** The emoji in the capture acknowledgement (`📝`) and the session-start reminders (`📚`, `💡`, `⚠️`) raised `UnicodeEncodeError` on Windows' default code page, tripping each hook's top-level handler. Hooks now force UTF-8 stdout/stderr at startup via `ensure_utf8_stdout()`.
+
 ## [3.1.0] - 2026-03-16
 
 ### Added

--- a/scripts/capture_learning.py
+++ b/scripts/capture_learning.py
@@ -19,12 +19,16 @@ from lib.reflect_utils import (
     detect_patterns,
     create_queue_item,
     should_include_message,
+    ensure_utf8_stdout,
     MAX_CAPTURE_PROMPT_LENGTH,
 )
 
 
 def main() -> int:
     """Main entry point."""
+    # Make output UTF-8 so the emoji acknowledgement can't crash on Windows cp1252.
+    ensure_utf8_stdout()
+
     # Read JSON from stdin
     input_data = sys.stdin.read()
     if not input_data:

--- a/scripts/lib/reflect_utils.py
+++ b/scripts/lib/reflect_utils.py
@@ -6,6 +6,7 @@ Cross-platform compatible (Windows, macOS, Linux).
 import json
 import re
 import os
+import sys
 from pathlib import Path
 from datetime import datetime, timezone
 from typing import List, Dict, Any, Optional, Tuple
@@ -341,16 +342,35 @@ def suggest_claude_file(
 # Auto memory utilities
 # =============================================================================
 
+def _encode_path_to_folder_name(path_str: str) -> str:
+    """Encode an absolute path string the way Claude Code names project folders.
+
+    Every path separator AND the Windows drive colon are replaced with a single
+    dash, so the result is always a single legal directory-name component on
+    every platform::
+
+        /Users/bob/myapp        ->  -Users-bob-myapp
+        C:\\Users\\bob\\myapp   ->  C--Users-bob-myapp
+
+    The colon MUST be replaced: a directory name containing ':' is illegal on
+    Windows (raises WinError 267/123 on mkdir), which previously made the
+    learnings-queue / auto-memory writes throw and the capture hook fail
+    silently. We deliberately do NOT re-prepend a leading dash: on POSIX the
+    leading '/' already encodes to '-', and on Windows a drive-letter path
+    correctly has none, matching Claude Code's own folder names under
+    ~/.claude/projects/ (e.g. C--Users-bob-myapp, not -C--Users-bob-myapp).
+    """
+    return re.sub(r"[\\/:]", "-", path_str)
+
+
 def get_project_folder_name(project_dir: Optional[str] = None) -> str:
     """Encode a project directory path using Claude Code's folder naming convention.
 
-    /Users/bob/myapp → -Users-bob-myapp
+    /Users/bob/myapp        ->  -Users-bob-myapp
+    C:\\Users\\bob\\myapp   ->  C--Users-bob-myapp
     """
     project_path = Path(project_dir).resolve() if project_dir else Path.cwd().resolve()
-    folder_name = str(project_path).replace("/", "-").replace("\\", "-")
-    if folder_name.startswith("-"):
-        folder_name = folder_name[1:]
-    return "-" + folder_name
+    return _encode_path_to_folder_name(str(project_path))
 
 
 def get_auto_memory_path(project_dir: Optional[str] = None) -> Path:
@@ -1171,3 +1191,28 @@ def aggregate_tool_errors(
     aggregated.sort(key=lambda x: x["count"], reverse=True)
 
     return aggregated
+
+
+# =============================================================================
+# Output utilities
+# =============================================================================
+
+def ensure_utf8_stdout() -> None:
+    """Force stdout/stderr to UTF-8 so hook output can't crash on Windows.
+
+    Windows consoles default to cp1252, which cannot encode the emoji used in
+    hook messages (e.g. 📝, 📚, 💡, ⚠️). Printing one raises UnicodeEncodeError,
+    which trips a hook's top-level ``except`` handler, discarding the
+    acknowledgement and writing a spurious "error" line to stderr on every
+    correction. Hooks call this once at startup so their stdout is portable.
+    No-ops safely when the stream can't be reconfigured (already wrapped,
+    detached, or replaced, e.g. under a test harness).
+    """
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        try:
+            reconfigure(encoding="utf-8")
+        except (ValueError, OSError):
+            pass

--- a/scripts/session_start_reminder.py
+++ b/scripts/session_start_reminder.py
@@ -11,11 +11,14 @@ import os
 # Add parent directory to path for imports
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from lib.reflect_utils import load_queue, get_cleanup_period_days
+from lib.reflect_utils import load_queue, get_cleanup_period_days, ensure_utf8_stdout
 
 
 def main() -> int:
     """Main entry point."""
+    # Make output UTF-8 so the emoji reminders can't crash on Windows cp1252.
+    ensure_utf8_stdout()
+
     # Check if reminder is disabled via environment variable
     if os.environ.get("CLAUDE_REFLECT_REMINDER", "true").lower() == "false":
         return 0

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -482,5 +482,76 @@ class TestBashPythonOutputEquivalence(unittest.TestCase):
         self.assertEqual(bash_lines, python_lines)
 
 
+class TestCaptureLearningHook(unittest.TestCase):
+    """End-to-end tests for the capture_learning UserPromptSubmit hook.
+
+    Regression coverage for two Windows-specific silent failures that both made
+    the hook exit 0 while dropping the capture:
+      1. A drive colon in the encoded project folder (e.g. ``-C:-Users-...``)
+         made ``mkdir`` raise, so ``learnings-queue.json`` was never written.
+      2. The emoji acknowledgement crashed on cp1252 stdout, tripping the hook's
+         top-level ``except`` handler.
+    Runs on every platform: the queue folder is asserted colon-free, and the
+    hook is asserted not to have raised (which catches the stdout crash on
+    Windows runners).
+    """
+
+    def setUp(self):
+        self.temp_home = tempfile.mkdtemp()
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.temp_home, ignore_errors=True)
+
+    def _run_capture(self, prompt: str):
+        env = dict(os.environ)
+        # Point Path.home() at the throwaway dir on every platform
+        # (POSIX reads HOME, Windows reads USERPROFILE).
+        env["HOME"] = self.temp_home
+        env["USERPROFILE"] = self.temp_home
+        # Don't lean on a UTF-8 environment; the hook must be safe on its own.
+        env.pop("PYTHONUTF8", None)
+        env.pop("PYTHONIOENCODING", None)
+        return subprocess.run(
+            [sys.executable, str(PYTHON_SCRIPTS["capture_learning"])],
+            input=json.dumps({"prompt": prompt}),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            cwd=str(SCRIPTS_DIR),
+            env=env,
+        )
+
+    def test_correction_is_captured_to_queue(self):
+        """A correction prompt is persisted; the hook never raises or blocks."""
+        result = self._run_capture("no, use python not python3")
+        # Hook must never block the prompt.
+        self.assertEqual(result.returncode, 0)
+        # The top-level handler only writes this when something threw.
+        self.assertNotIn("capture_learning.py error", result.stderr)
+        # The learning must actually land on disk.
+        queue_files = list(Path(self.temp_home).rglob("learnings-queue.json"))
+        self.assertEqual(
+            len(queue_files), 1, f"expected one queue file, got {queue_files}"
+        )
+        # The encoded project folder must be a legal directory name (no colon).
+        self.assertNotIn(":", queue_files[0].parent.name)
+        items = json.loads(queue_files[0].read_text(encoding="utf-8"))
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0]["message"], "no, use python not python3")
+        self.assertEqual(items[0]["sentiment"], "correction")
+
+    def test_non_correction_is_not_captured(self):
+        """A neutral question is not queued, but the hook still initialises the queue."""
+        result = self._run_capture("what does this function do?")
+        self.assertEqual(result.returncode, 0)
+        self.assertNotIn("capture_learning.py error", result.stderr)
+        queue_files = list(Path(self.temp_home).rglob("learnings-queue.json"))
+        # Queue file is created (empty) but no learning is appended.
+        self.assertEqual(len(queue_files), 1)
+        items = json.loads(queue_files[0].read_text(encoding="utf-8"))
+        self.assertEqual(items, [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_memory_hierarchy.py
+++ b/tests/test_memory_hierarchy.py
@@ -18,6 +18,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
 from lib.reflect_utils import (
     _parse_rule_frontmatter,
+    _encode_path_to_folder_name,
     find_claude_files,
     suggest_claude_file,
     get_project_folder_name,
@@ -278,11 +279,44 @@ class TestAutoMemoryPath(unittest.TestCase):
         self.assertEqual(result, "-Users-bob-code-projects-myapp")
 
     def test_folder_name_encoding_structure(self):
-        """Test folder name encoding produces valid structure on any platform."""
+        """Test folder name encoding produces a legal directory name on any platform."""
         result = get_project_folder_name(tempfile.gettempdir())
-        self.assertTrue(result.startswith("-"))
+        # The encoded name becomes a single directory component under
+        # ~/.claude/projects/, so it must contain no path separator and no
+        # drive colon. A ':' is an illegal directory name on Windows and made
+        # the capture hook fail silently (WinError 267).
         self.assertNotIn("/", result)
         self.assertNotIn("\\", result)
+        self.assertNotIn(":", result)
+        if platform.system() != "Windows":
+            # POSIX absolute paths start with '/', which encodes to a leading '-'.
+            self.assertTrue(result.startswith("-"))
+
+    def test_folder_name_encoding_windows_drive(self):
+        """Windows drive-letter paths encode with no colon (regression for WinError 267).
+
+        Exercises the pure string encoder directly so this guard runs on every
+        OS (including the Linux/macOS CI runners), not just Windows. The drive
+        colon must become a dash, matching Claude Code's own project folders
+        (C:\\Users\\bob\\myapp -> C--Users-bob-myapp), so mkdir on the queue /
+        auto-memory directory cannot raise and silently drop captures.
+        """
+        result = _encode_path_to_folder_name(r"C:\Users\bob\myapp")
+        self.assertEqual(result, "C--Users-bob-myapp")
+        self.assertNotIn(":", result)
+        self.assertNotIn("\\", result)
+        # No spurious leading dash for drive-letter paths.
+        self.assertFalse(result.startswith("-"))
+
+    def test_folder_name_encoding_posix_via_encoder(self):
+        """POSIX paths keep their natural leading dash through the pure encoder."""
+        self.assertEqual(
+            _encode_path_to_folder_name("/Users/bob/myapp"), "-Users-bob-myapp"
+        )
+        self.assertEqual(
+            _encode_path_to_folder_name("/Users/bob/code/projects/myapp"),
+            "-Users-bob-code-projects-myapp",
+        )
 
     @unittest.skipIf(platform.system() == "Windows", "Unix-specific path encoding")
     @patch("lib.reflect_utils.get_claude_dir")


### PR DESCRIPTION
## What this fixes

`claude-reflect`'s correction-capture hook fails silently on Windows. Whatever the user types, `~/.claude/projects/<encoded>/learnings-queue.json` is never created and no corrections are recorded.

## Root cause

`get_project_folder_name()` encodes the project path by replacing `/` and `\` with `-`, but leaves the Windows drive colon in place:

```python
folder_name = str(project_path).replace("/", "-").replace("\\", "-")
if folder_name.startswith("-"):
    folder_name = folder_name[1:]
return "-" + folder_name
```

On Windows that turns `C:\Users\bob\app` into `-C:-Users-bob-app`. A `:` is illegal in a Windows directory name, so the `mkdir` inside `save_queue()` (and `get_auto_memory_path()`) raises `WinError 267`. `capture_learning.py`'s top-level `except Exception` swallows it and exits 0, so the failure is invisible.

`get_queue_path()` has a `try/except` fallback to the global path, but it never fires: building the `Path` is lazy, so nothing raises until the much-later `mkdir`.

The leading `-` is also wrong on Windows. Claude Code names the session folder `C--Users-bob-app` (drive colon to dash, no leading dash), confirmed against `~/.claude/projects/` on a real machine.

### Verified repro (Windows 11, before the fix)

```
$ printf '{"prompt":"no, use python not python3"}' | python scripts/capture_learning.py
Warning: capture_learning.py error: [WinError 267] The directory name is invalid:
  '...\.claude\projects\-C:-Users-...-claude-reflect'
exit code: 0
# no learnings-queue.json written
```

## The fix

A single pure encoder, used everywhere:

```python
def _encode_path_to_folder_name(path_str: str) -> str:
    return re.sub(r"[\\/:]", "-", path_str)
```

- POSIX output is unchanged: `/Users/bob/app` -> `-Users-bob-app` (the leading dash comes from the leading `/`).
- Windows now matches Claude Code: `C:\Users\bob\app` -> `C--Users-bob-app`.

Both callers (`get_queue_path`, `extract_tool_errors`) route through it.

## A second Windows bug found while verifying

After the path fix the queue file is written, but the `📝 Learning captured` acknowledgement (and the `📚`, `💡`, `⚠️` session-start reminders) raise `UnicodeEncodeError` on Windows' cp1252 console, which trips the same top-level handler. CI never caught this because its smoke-test prompt (`"test"`) is not a correction, so the print line is never reached.

A shared `ensure_utf8_stdout()` forces UTF-8 on stdout/stderr at hook startup and no-ops where the stream can't be reconfigured. Wired into `capture_learning.py` and `session_start_reminder.py`.

### After the fix

```
$ printf '{"prompt":"no, use python not python3"}' | python scripts/capture_learning.py
📝 Learning captured: 'no, use python not python3' (confidence: 85%)
exit code: 0
# .../projects/C--Users-...-claude-reflect/learnings-queue.json written, stderr empty
```

## Tests

- `test_folder_name_encoding_structure` now asserts the absence of a colon. It passed before despite the bug because it only checked for `/` and `\` and that the name starts with `-`, which the buggy code happened to satisfy.
- `test_folder_name_encoding_windows_drive` and `test_folder_name_encoding_posix_via_encoder` exercise the pure encoder, so they also run on the Linux and macOS CI runners, not just Windows.
- `TestCaptureLearningHook` runs `capture_learning.py` end to end with a throwaway `HOME` and `PYTHONUTF8` unset, asserting the queue lands in a colon-free folder and the hook never raises. This guard covers both bugs and fails on the old code.

Full suite on Windows: `212 passed, 14 skipped`. POSIX behaviour is unchanged.

Added an `Unreleased` CHANGELOG entry and left the version bump to you per `RELEASING.md`.
