### PR TITLE
fix(commands): resolve bundled script paths via ${CLAUDE_SKILL_DIR}

### DIFF
--- a/commands/reflect-skills.md
+++ b/commands/reflect-skills.md
@@ -98,7 +98,7 @@ find "$SESSION_PATH" -name "*.jsonl" -mtime -14 -type f 2>/dev/null
 
 ```bash
 # Use the plugin's extraction script - DO NOT reinvent with bash/jq
-python3 "${CLAUDE_PLUGIN_ROOT}/scripts/extract_session_learnings.py" "$SESSION_FILE"
+python3 "${CLAUDE_SKILL_DIR}/../scripts/extract_session_learnings.py" "$SESSION_FILE"
 ```
 
 The extraction script handles:

--- a/commands/reflect.md
+++ b/commands/reflect.md
@@ -17,7 +17,7 @@ allowed-tools: Read, Edit, Write, Glob, Bash, Grep, AskUserQuestion, TodoWrite
 ## Context
 - Project CLAUDE.md: @CLAUDE.md
 - Global CLAUDE.md: @~/.claude/CLAUDE.md
-- Learnings queue (per-project): !`python3 "$(dirname "$(dirname "$(readlink -f "$0")")")/scripts/read_queue.py" 2>/dev/null || echo "[]"`
+- Learnings queue (per-project): !`python3 "${CLAUDE_SKILL_DIR}/../scripts/read_queue.py" 2>/dev/null || echo "[]"`
 - Current project: !`pwd`
 
 ## Multi-Target Export
@@ -686,7 +686,7 @@ Tool execution errors (`is_error: true`) that indicate project-specific issues:
 
 **Use the extraction script:**
 ```bash
-python scripts/extract_tool_errors.py --project "$(pwd)" --min-count 2 --json
+python "${CLAUDE_SKILL_DIR}/../scripts/extract_tool_errors.py" --project "$(pwd)" --min-count 2 --json
 ```
 
 Or use the utility functions directly:

--- a/commands/skip-reflect.md
+++ b/commands/skip-reflect.md
@@ -4,7 +4,7 @@ allowed-tools: Bash
 ---
 
 ## Context
-- Queue count: !`python3 scripts/read_queue.py 2>/dev/null | python3 -c "import sys,json;print(len(json.load(sys.stdin)))" 2>/dev/null || echo 0`
+- Queue count: !`python3 "${CLAUDE_SKILL_DIR}/../scripts/read_queue.py" 2>/dev/null | python3 -c "import sys,json;print(len(json.load(sys.stdin)))" 2>/dev/null || echo 0`
 
 ## Your Task
 
@@ -21,8 +21,8 @@ allowed-tools: Bash
    - Clear the project queue:
    ```bash
    python3 -c "
-   import sys, os
-   sys.path.insert(0, os.path.join(os.environ.get('CLAUDE_PLUGIN_ROOT', '.'), 'scripts'))
+   import sys
+   sys.path.insert(0, '${CLAUDE_SKILL_DIR}/../scripts')
    from lib.reflect_utils import save_queue
    save_queue([])
    "

--- a/commands/view-queue.md
+++ b/commands/view-queue.md
@@ -42,7 +42,7 @@ or corrections will be auto-detected. Run /reflect to process.
 
 **Step 1: Read the project-scoped queue file:**
 ```bash
-python3 scripts/read_queue.py 2>/dev/null || echo "[]"
+python3 "${CLAUDE_SKILL_DIR}/../scripts/read_queue.py" 2>/dev/null || echo "[]"
 ```
 
 **Step 2: Parse and format each item with:**


### PR DESCRIPTION
## Problem

The `/reflect`, `/skip-reflect`, `/view-queue`, and `/reflect-skills` commands reference their bundled `scripts/*.py` with paths that don't resolve when a command is invoked from the user's **project directory** (the normal case):

| File | Current | Why it fails |
|---|---|---|
| `skip-reflect.md`, `view-queue.md` | `python3 scripts/read_queue.py` | bare relative path, resolved against the user's CWD (not the plugin dir), so the script is not found |
| `reflect.md` | `$(dirname "$(dirname "$(readlink -f "$0")")")/scripts/...` | per the [skills docs](https://code.claude.com/docs/en/skills), `$0` is the command's **first argument**, not the command file path, so the readlink/dirname trick misresolves |
| `reflect-skills.md` | `${CLAUDE_PLUGIN_ROOT}/scripts/...` | `${CLAUDE_PLUGIN_ROOT}` is **not** among the substitutions available inside skill/command markdown (only `SESSION_ID` / `EFFORT` / `SKILL_DIR` are), so it stays literal |

### Observable symptom

`/skip-reflect` always prints **`Queue count: 0`** even when the queue is non-empty: the inline `` !`...` `` count command cannot find `read_queue.py`, errors, and the `|| echo 0` fallback fires — so the user is told the queue is empty when it is not.

## Fix

Use the documented [`${CLAUDE_SKILL_DIR}`](https://code.claude.com/docs/en/skills#available-string-substitutions) substitution, which the skills docs recommend specifically for "reference scripts or files bundled with the skill, regardless of the current working directory."

Scripts live at the plugin root's `scripts/` while commands live in `commands/`, so the path becomes `${CLAUDE_SKILL_DIR}/../scripts/<script>`. This also matches the structural intent of the existing `dirname`-based resolution in `reflect.md`.

## Note for maintainer

This assumes `${CLAUDE_SKILL_DIR}` for a plugin **command** resolves to the command's containing directory (`commands/`). If it resolves to the plugin root in your testing, drop the `/..` (→ `${CLAUDE_SKILL_DIR}/scripts/...`). The cwd-relative failure and the `${CLAUDE_SKILL_DIR}` recommendation are confirmed against the official docs; I could not unit-test the exact offset for command-style files.

Related: #17 (`${CLAUDE_PLUGIN_ROOT}` not set for hooks).
