### PR TITLE
fix: stop capturing plain statements that begin with "no"

### DIFF
--- a/scripts/capture_learning.py
+++ b/scripts/capture_learning.py
@@ -76,7 +76,9 @@ def main() -> int:
         # Output feedback for Claude to acknowledge the capture
         # UserPromptSubmit hooks with exit code 0 add stdout as context
         preview = prompt[:40] + "..." if len(prompt) > 40 else prompt
-        print(f"📝 Learning captured: '{preview}' (confidence: {confidence:.0%})")
+        # Plain ASCII: Windows consoles default to cp1252 and raise
+        # UnicodeEncodeError on emoji, which swallowed this confirmation.
+        print(f"[reflect] Learning captured: '{preview}' (confidence: {confidence:.0%})")
 
     return 0
 

--- a/scripts/lib/reflect_utils.py
+++ b/scripts/lib/reflect_utils.py
@@ -458,7 +458,16 @@ POSITIVE_PATTERNS = [
 # - Users can use explicit markers like "remember:" in any language
 #
 CORRECTION_PATTERNS = [
-    (r"^no[,. ]+", "no,", True),  # Starts with "no," - common correction opener
+    (r"^no[,.]+", "no,", True),  # Starts with "no," / "no." - correction opener
+    # Bare "no " needs an addressee or clause marker after it, otherwise plain
+    # statements of fact ("no dialog appeared", "no idea", "no problem") match.
+    (
+        r"^no\s+(?:it|its|it's|that|this|these|those|i|i'm|you|you're|we|we're|they|he|she"
+        r"|do|don'?t|doesn'?t|didn'?t|not|use|using|need|keep|make|put|let'?s"
+        r"|bro|man|mate|dude|sorry|wait|the\s+other|the\s+first|the\s+second)\b",
+        "no-addressed",
+        True,
+    ),
     (r"^don't\b|^do not\b", "don't", True),  # Starts with don't/do not
     (r"^stop\b|^never\b", "stop/never", True),  # Starts with stop/never
     (r"that's (wrong|incorrect)|that is (wrong|incorrect)", "that's-wrong", True),
@@ -506,6 +515,12 @@ MAX_WEAK_PATTERN_LENGTH = 150
 # Very short messages without question marks are more likely corrections
 MIN_SHORT_CORRECTION_LENGTH = 80
 
+# Minimum length for a positive to be worth queueing.
+# Bare praise ("i love it", "perfect!", "nailed it") has no referent — by the
+# time /reflect runs, there is no way to tell what was being praised, so it
+# cannot become a memory. Longer positives usually name the thing.
+MIN_POSITIVE_CONTEXT_LENGTH = 25
+
 
 def detect_patterns(text: str) -> Tuple[Optional[str], str, float, str, int]:
     """
@@ -542,6 +557,10 @@ def detect_patterns(text: str) -> Tuple[Optional[str], str, float, str, int]:
             matched_positive.append(name)
 
     if matched_positive:
+        # Bare praise carries no referent — drop it rather than queue an
+        # item that /reflect cannot turn into anything.
+        if len(text.strip()) < MIN_POSITIVE_CONTEXT_LENGTH:
+            return (None, "", 0.0, "positive", 90)
         return ("positive", " ".join(matched_positive), 0.70, "positive", 90)
 
     # Skip long messages for weak patterns (likely task requests)

--- a/tests/test_reflect_utils.py
+++ b/tests/test_reflect_utils.py
@@ -297,6 +297,58 @@ class TestPatternDetection(unittest.TestCase):
 
         self.assertIsNone(item_type)
 
+    def test_bare_no_statement_rejected(self):
+        """Statements that merely start with the word 'no' are not corrections.
+
+        Regression: '^no[,. ]+' allowed a bare space, so any sentence opening
+        with "no" was captured — including answers to Claude's own questions.
+        """
+        for text in [
+            "no dialog appeared",
+            "no idea",
+            "no problem",
+            "no worries",
+            "no rush on this",
+            "no results came back",
+        ]:
+            with self.subTest(text=text):
+                item_type, _, _, _, _ = detect_patterns(text)
+                self.assertIsNone(item_type, f"false positive on: {text}")
+
+    def test_addressed_no_still_captured(self):
+        """Real corrections opening with a bare 'no' must still be captured."""
+        for text in [
+            "no you got that wrong - they take time for each game",
+            "no bro Melik said that but that's Melik's vocabulary",
+            "no it should use the other endpoint",
+            "no don't touch that file",
+            "no I meant the second one",
+        ]:
+            with self.subTest(text=text):
+                item_type, _, _, _, _ = detect_patterns(text)
+                self.assertIsNotNone(item_type, f"missed correction: {text}")
+
+    def test_punctuated_no_still_captured(self):
+        """The canonical 'no, use X' form is unaffected by the fix."""
+        item_type, patterns, _, _, _ = detect_patterns("no, use gpt-5.1 not gpt-5")
+        self.assertIsNotNone(item_type)
+        self.assertIn("no,", patterns)
+
+    def test_bare_positive_rejected(self):
+        """Praise with no referent cannot become a memory, so it is dropped."""
+        for text in ["i love it", "perfect!", "nailed it", "excellent"]:
+            with self.subTest(text=text):
+                item_type, _, _, _, _ = detect_patterns(text)
+                self.assertIsNone(item_type, f"contentless positive queued: {text}")
+
+    def test_positive_with_context_still_captured(self):
+        """Positives that name what they praise are still worth queueing."""
+        item_type, _, _, sentiment, _ = detect_patterns(
+            "love it, keep the tables compact like that in future reports"
+        )
+        self.assertEqual(item_type, "positive")
+        self.assertEqual(sentiment, "positive")
+
     def test_short_message_confidence_boost(self):
         """Test that short messages get a confidence boost."""
         result = detect_patterns("no, use gpt-5.1")


### PR DESCRIPTION
Two small fixes to the `UserPromptSubmit` capture hook, found while processing a queue where 4 of 5 items were false positives.

## 1. Bare "no" statements captured as corrections

`CORRECTION_PATTERNS` opens with `^no[,. ]+`. The character class includes a bare space, so it matches the *word* "no" starting any sentence — not the intended "No, …" correction form. `no dialog appeared`, `no idea`, `no problem`, `no worries` all queue as corrections.

In practice the most common source is the assistant asking a diagnostic question and the user answering "no …" — the reply gets logged as a correction against them.

Split into the punctuated form (`^no[,.]+`) plus a bare form requiring an addressee or clause marker after it (`no you…`, `no it…`, `no don't…`, `no bro…`). Verified against a real queue: genuine corrections like "no you got that wrong" and "no bro, Melik said that" still capture.

## 2. Contentless positives

`love it` / `perfect!` / `nailed it` match `POSITIVE_PATTERNS` correctly, but a bare positive has no referent — by the time `/reflect` runs there is no way to recover what was being praised, so the item cannot become a memory. Now dropped below 25 characters; positives that name the thing still queue.

## 3. Drive-by: emoji in the confirmation breaks on Windows

The capture confirmation used a `📝` emoji. Windows consoles default to cp1252 and raise `UnicodeEncodeError` on it, so every successful capture hit the module-level except handler and printed a stderr warning instead of the confirmation. The queue write happens first, so nothing was lost — but the user never saw that a learning had been captured. Kept as a separate commit.

## Testing

5 regression tests added covering both the rejected and still-captured cases. Suite is 188 passing.

The 3 failures in `test_memory_hierarchy.py` are pre-existing Windows path-encoding issues, present on `main` before these changes and untouched by them.
